### PR TITLE
Made a failure to tune fs a warning

### DIFF
--- a/storage/vbr.c
+++ b/storage/vbr.c
@@ -931,8 +931,7 @@ static int copy_creator (artifact * a)
         // tune file system, which is needed to boot EMIs fscked long ago
         logprintfl (EUCAINFO, "[%s] tuning root file system on disk %d partition %d\n", a->instanceId, vbr->diskNumber, vbr->partitionNumber);
         if (diskutil_tune (dev) == ERROR) {
-            logprintfl (EUCAERROR, "[%s] error: failed to tune root file system: %s\n", a->instanceId, blobstore_get_last_msg());
-            return ERROR;
+            logprintfl (EUCAWARN, "[%s] error: failed to tune root file system: %s\n", a->instanceId, blobstore_get_last_msg());
         }
     }
     


### PR DESCRIPTION
When the root file system is not recognized by tune2fs, and error will
prevent the booting of the instance, even though the root file system may
be legitimate (for example xfs, or btrfs, or others). This patch (2
liners) will change the error into a WARNING and allow the boot to
proceed.
