### PR TITLE
Correct spelling.

### DIFF
--- a/clc/modules/dns/src/main/java/com/eucalyptus/cloud/ws/DNSControl.java
+++ b/clc/modules/dns/src/main/java/com/eucalyptus/cloud/ws/DNSControl.java
@@ -147,7 +147,7 @@ public class DNSControl {
 			initializeUDP();
 			initializeTCP();
 		} catch(Exception ex) {
-			LOG.error("DNS could not be initialized. Is some other srvice running on port 53?");
+			LOG.error("DNS could not be initialized. Is some other service running on port 53?");
 			throw ex;
 		}
 	}


### PR DESCRIPTION
Add a single letter to correct the spelling of "service".
