### PR TITLE
Bump default instance type parameters

### DIFF
--- a/clc/modules/cluster-manager/src/main/java/com/eucalyptus/util/MetadataStateBootstrapper.java
+++ b/clc/modules/cluster-manager/src/main/java/com/eucalyptus/util/MetadataStateBootstrapper.java
@@ -99,11 +99,11 @@ public class MetadataStateBootstrapper extends Bootstrapper.Simple {
     EntityWrapper<VmType> db = EntityWrapper.get( VmType.class );
     try {
       if ( db.query( new VmType( ) ).size( ) == 0 ) { //TODO: make defaults configurable?
-        db.add( new VmType( "m1.small", 1, 2, 128 ) );
-        db.add( new VmType( "c1.medium", 1, 5, 256 ) );
-        db.add( new VmType( "m1.large", 2, 10, 512 ) );
-        db.add( new VmType( "m1.xlarge", 2, 20, 1024 ) );
-        db.add( new VmType( "c1.xlarge", 4, 20, 2048 ) );
+        db.add( new VmType( "m1.small",  1,  5,  512 ) );
+        db.add( new VmType( "c1.medium", 2, 10,  512 ) );
+        db.add( new VmType( "m1.large",  2, 15, 1024 ) );
+        db.add( new VmType( "m1.xlarge", 2, 20, 2048 ) );
+        db.add( new VmType( "c1.xlarge", 4, 20, 4096 ) );
       }
       db.commit( );
     } catch ( Exception e ) {

--- a/clc/modules/cluster-manager/src/main/java/com/eucalyptus/vm/VmTypes.java
+++ b/clc/modules/cluster-manager/src/main/java/com/eucalyptus/vm/VmTypes.java
@@ -201,11 +201,11 @@ public class VmTypes {
       }
 
       if ( vmTypeList.isEmpty( ) ) {
-        db.add( new VmType( "m1.small", 1, 2, 128 ) );
-        db.add( new VmType( "c1.medium", 2, 5, 128 ) );
-        db.add( new VmType( "m1.large", 2, 10, 512 ) );
-        db.add( new VmType( "m1.xlarge", 2, 10, 1024 ) );
-        db.add( new VmType( "c1.xlarge", 4, 10, 2048 ) );
+        db.add( new VmType( "m1.small",  1,  5,  512 ) );
+        db.add( new VmType( "c1.medium", 2, 10,  512 ) );
+        db.add( new VmType( "m1.large",  2, 15, 1024 ) );
+        db.add( new VmType( "m1.xlarge", 2, 20, 2048 ) );
+        db.add( new VmType( "c1.xlarge", 4, 20, 4096 ) );
       }
       db.commit( );
     } catch ( Exception e ) {


### PR DESCRIPTION
The default parameters for instance types are far too small for modern
hardware and software.  This commit bumps them to the following values:
- m1.small:  1 CPU,   5 GB disk,  512 MB RAM
- c1.medium: 2 CPUs, 10 GB disk,  512 MB RAM
- m1.large:  2 CPUs, 15 GB disk, 1024 MB RAM
- m1.xlarge: 2 CPUs, 20 GB disk, 2048 MB RAM
- c1.xlarge: 4 CPUs, 20 GB disk, 4096 MB RAM
