### PR TITLE
euca_conf --deregister-nodes multiple host parameter fix

### DIFF
--- a/clc/eucadmin/bin/euca_conf.in
+++ b/clc/eucadmin/bin/euca_conf.in
@@ -867,12 +867,15 @@ class EucaConf(object):
     def do_deregister_nodes(self):
         if self.options.dereg_nodes:
             current_nodes = self.config['NODES'].split()
-            for node in self.options.dereg_nodes:
-                if node in current_nodes:
-                    current_nodes.remove(node)
-                else:
-                    self.warn('Node %s is not currently registered' % node)
+            for node_string in self.options.dereg_nodes:
+                nodes_to_remove = node_string.split()
+                for node in nodes_to_remove:
+                    if node in current_nodes:
+                        current_nodes.remove(node)
+                    else:
+                        self.warn('Node %s is not currently registered' % node)
             self.config['NODES'] = ' '.join(current_nodes)
+            print '...done'
 
     def do_help_register(self):
         if self.options.help_register:


### PR DESCRIPTION
euca_conf --deregister-nodes doesn't seem to take more than one parameter.

`````` bash
root@g-08-04:~# euca_conf --deregister-nodes "10.105.1.165 10.105.1.166"
Node 10.105.1.165 10.105.1.166 is not currently registered
root@g-08-04:~# grep NODES /etc/eucalyptus/eucalyptus.conf
NODES="10.105.1.165 10.105.1.166"
root@g-08-04:~# euca_conf --deregister-nodes "10.105.1.165"
root@g-08-04:~#```
``````
