### PR TITLE
A fix for EUCA-3659

### DIFF
--- a/clc/modules/wsstack/src/main/java/com/eucalyptus/ws/handlers/WalrusAuthenticationHandler.java
+++ b/clc/modules/wsstack/src/main/java/com/eucalyptus/ws/handlers/WalrusAuthenticationHandler.java
@@ -227,15 +227,18 @@ public class WalrusAuthenticationHandler extends MessageStackHandler {
 	}
 
 	private String combineMultilineHeader(String header) {
-		String value =  header.trim();
-		String[] parts = value.split("\n");
-		value = "";
-		for(String part: parts) {
-			part = part.trim();
-			value += part + " ";
-		}
-		value = value.trim();
+		StringBuilder result = new StringBuilder();
+		String[] parts = header.trim().split("\n");
 
+		for(String part: parts) {
+			result.append(part.trim());
+			result.append(" ");
+		}
+		// Delete the final space
+		if (values.length() > 0)
+			result.deleteCharAt(values.length() -1);
+
+		return result.toString();
 	}
 
 	private String getCanonicalizedAmzHeaders(MappingHttpRequest httpRequest) {


### PR DESCRIPTION
This set of patches should fix the EUCA-3659 bug.

Note that since first writing these commits, I've done some interactive rebasing, after which I have not been able to compile the source code of these specific commits. It is possible that they will not compile. Sorry about that.

Note that the branch started off as a "daggy fix", i.e. it is rooted at the point where the original bug was introduced. It does apply cleanly to at least last Friday's master. In order to make the patches useful, you may want to rebase or merge it with the master.

The meat of the fix is in the first commit, the last three are mostly just refactoring this and that.

Finally, note that the code computing the canonical header probably should not be in the Handler class, but rather in the Request class (or a subclass of it). The operation is, after all, specific to HTTP. I did not purse this further, since I don't know the lay of the land, architecturally speaking.

I have signed the CLA.
