### PR TITLE
EUCA-4696: Use the standard default value for clcwebport

### DIFF
--- a/console/eucaconsole/__init__.py
+++ b/console/eucaconsole/__init__.py
@@ -121,7 +121,7 @@ class GlobalSession(object):
     
     @property
     def admin_console_url(self):
-        port = self.get_value('server', 'clcwebport')
+        port = self.get_value('server', 'clcwebport', default_val='8443')
         url = 'https://' + self.get_value('server', 'clchost')
         if port != '443':
             url += ':' + port


### PR DESCRIPTION
As mentioned in EUCA-4696, upgrades from 3.2.0 to 3.2.1 break if a user doesn't define clcwebport in their config file.  This patch uses 8443 as a default in the code when clcwebport is not defined.
