### PR TITLE
fixes EUCA-5707: set proper instance migration state when migration fails

### DIFF
--- a/node/handlers.c
+++ b/node/handlers.c
@@ -3037,6 +3037,8 @@ int migration_rollback_src(ncInstance * instance)
         return TRUE;
     }
     // Not source node?
-    LOGERROR("[%s] request to roll back migration of instance on non-source/destination node %s\n", instance->instanceId, nc_state.ip)
+    LOGERROR("[%s] request to roll back migration of instance on non-source/destination node %s\n", instance->instanceId, nc_state.ip);
+        instance->migration_state = NOT_MIGRATING;
+        save_instance_struct(instance);
         return FALSE;
 }


### PR DESCRIPTION
when the `migration_rollback_src` happens, it sets the migration state back to not migrating.
