### PR TITLE
backport-util-concurrent dependency removal

### DIFF
--- a/clc/.classpath
+++ b/clc/.classpath
@@ -48,7 +48,6 @@
 	<classpathentry exported="true" kind="lib" path="lib/axiom-api-1.2.8.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/axiom-dom-1.2.8.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/axiom-impl-1.2.8.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/backport-util-concurrent-2.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/bcel-5.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/bcprov.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/bsf-2.4.0.jar"/>

--- a/clc/modules/msgs/src/main/java/com/eucalyptus/component/ComponentMessages.java
+++ b/clc/modules/msgs/src/main/java/com/eucalyptus/component/ComponentMessages.java
@@ -76,7 +76,7 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
-import edu.emory.mathcs.backport.java.util.Collections;
+import java.util.Collections;
 import edu.ucsb.eucalyptus.msgs.BaseMessage;
 
 public class ComponentMessages {


### PR DESCRIPTION
Hi,

The project depends on backport-util-concurrent, the library is used only once for calling Collections.emptyList(). This dependency could be safely removed, the JDK provides the same implementation.
