### PR TITLE
EUCA-6483

### DIFF
--- a/node/handlers.c
+++ b/node/handlers.c
@@ -2278,7 +2278,7 @@ static int init(void)
 
     if (nc_state.config_max_mem && nc_state.config_max_mem > nc_state.mem_max)
         nc_state.mem_max = nc_state.config_max_mem;
-        LOGWARN("MAX_MEM is now greater than the amount of physical memory: %lldMB\n", nc_state.mem_max);
+        LOGWARN("MAX_MEM value is now greater than the amount of physical memory: %lldMB\n", nc_state.mem_max);
 
     if (nc_state.config_max_cores) {
         nc_state.cores_max = nc_state.config_max_cores;


### PR DESCRIPTION
PR for a suggested fix for EUCA-6483 (now against the right branch). @dmitrii suggested adding a log message to indicate a warning that the NC is performing an overcommit of memory resource.
