### PR TITLE
Added fix for EUCA-4329

### DIFF
--- a/clc/modules/cluster-manager/src/main/java/com/eucalyptus/vm/VmInstance.java
+++ b/clc/modules/cluster-manager/src/main/java/com/eucalyptus/vm/VmInstance.java
@@ -1238,7 +1238,11 @@ public class VmInstance extends UserMetadata<VmState> implements VmInstanceMetad
     if ( this.bootRecord.getMachine( ) instanceof MachineImageInfo ) {
       m.put( "ami-manifest-path", ( ( MachineImageInfo ) this.bootRecord.getMachine( ) ).getManifestLocation( ) );
     }
-    m.put( "hostname", this.getPublicAddress( ) );
+    if ( dns ) {
+      m.put( "hostname", this.getNetworkConfig( ).getPrivateDnsName( ) );
+    } else {
+      m.put( "hostname", this.getNetworkConfig( ).getPrivateAddress( ) );
+    }
     m.put( "instance-id", this.getInstanceId( ) );
     m.put( "instance-type", this.getVmType( ).getName( ) );
     if ( dns ) {


### PR DESCRIPTION
This is a fix for getting the instance metadata service attributes hostname and local-hostname to match.  This issue causes AWS metadata service testing in instances to fail when looking to match hostname of the metadata service to the hostname of the instance.
