### PR TITLE
Added updated fix to VT enable testing - EUCA-4231

### DIFF
--- a/tools/eucalyptus-nc.in
+++ b/tools/eucalyptus-nc.in
@@ -169,8 +169,7 @@ do_start() {
 
     	# Be heavy-handed, exit with failure on lack of CPU virtualization support.
 
-        VIRTCHK=`egrep -m1 -w '^flags[[:blank:]]*:' /proc/cpuinfo | egrep -wo '(vmx|svm)'`
-    	if [ -z $VIRTCHK ] ; then
+    	if ! grep -Evq '^flags.* (svm|vmx)( |$)' /proc/cpuinfo; then
         	echo "Terminating! This Node Controller does not have CPU virtualization support. You will not be able to run instances."
         	echo 
         	$EUCALYPTUS/usr/sbin/euca-generate-fault -c nc 1013 component nc     


### PR DESCRIPTION
With the current VT enable test, when the NC is started, the following is seen:

```
# service eucalyptus-nc start
Starting Eucalyptus services: vmx
done.
```

This fix makes sure the following behavior is seen:

```
# service eucalyptus-nc start
Starting Eucalyptus services: done.
```
