### PR TITLE
EUCA-6756 - defined setCountLimit to unlimited to ensure there wasn't client side limitation for number of LDAP search results returned

### DIFF
--- a/clc/modules/authentication/src/main/java/com/eucalyptus/auth/ldap/LdapClient.java
+++ b/clc/modules/authentication/src/main/java/com/eucalyptus/auth/ldap/LdapClient.java
@@ -136,6 +136,7 @@ public class LdapClient {
     searchControls.setDerefLinkFlag( true );
     searchControls.setSearchScope( SearchControls.SUBTREE_SCOPE );
     searchControls.setTimeLimit( TIMEOUT_IN_MILLIS );
+    searchControls.setCountLimit( 0 );
     try {
       return context.search( baseDn, filter, searchControls );
     } catch ( NamingException e ) {


### PR DESCRIPTION
Defined setCountLimit to unlimited to ensure there wasn't client side limitation for number of LDAP search results returned.

By default, global defaults for sizelimit is 500 entries.  This patch ensures that the client doesn't have a sizelimit set, and follows whatever  sizelimit is defined by the LDAP/AD server.
