### PR TITLE
Attempt to increase usefulness of LOGERROR msg :)

### DIFF
--- a/storage/objectstorage.c
+++ b/storage/objectstorage.c
@@ -602,7 +602,7 @@ char *objectstorage_get_digest(const char *url)
 
     int tmp_fd = safe_mkstemp(digest_path);
     if (tmp_fd < 0) {
-        LOGERROR("failed to create a digest file %s\n", digest_path);
+        LOGERROR("failed to create a digest file %s unable to write to /tmp\n", digest_path);
     } else {
         close(tmp_fd);                 // objectstorage_ routine will reopen the file
 


### PR DESCRIPTION
This is an attempt to increase the usefulness of this specific log message.  We attempt to create a tmpfile using mkstemp and if this fails then we state we are unable to create a digest file.  If it fails, then _for some reason_ we are unable to write to /tmp.  This will at least help the user understand the action we are trying to take, they can then find out why it is failing themselves (by checking available space, perms, file descriptor limits etc.). 
