### PR TITLE
EUCA-8835 Postgresql log entries now have timestamps

### DIFF
--- a/clc/modules/postgresql/conf/scripts/setup_db.groovy
+++ b/clc/modules/postgresql/conf/scripts/setup_db.groovy
@@ -365,6 +365,7 @@ ${hostOrHostSSL}\tall\tall\t::/0\tpassword
     try {
       final Map<String,String> requiredProperties = [
             max_connections: '8192',
+            log_line_prefix: "'%t'",
             unix_socket_directory: "'" + SubDirectory.DB.getChildPath( EUCA_DB_DIR ) + "'",
             unix_socket_directories: "'" + SubDirectory.DB.getChildPath( EUCA_DB_DIR ) + "'",
             ssl: PG_USE_SSL ? 'on' : 'off',


### PR DESCRIPTION
enabled timestamps in postgres logs. 
