### PR TITLE
Fixes EUCA-12540

### DIFF
--- a/cluster/config-cc.h
+++ b/cluster/config-cc.h
@@ -101,7 +101,7 @@ configEntry configKeysRestartCC[] = {
     ,
     {"VNET_MACMAP", NULL}
     ,
-    {"VNET_MODE", "SYSTEM"}
+    {"VNET_MODE", NETMODE_INVALID}
     ,
     {"VNET_NETMASK", NULL}
     ,

--- a/node/handlers.c
+++ b/node/handlers.c
@@ -2779,8 +2779,8 @@ static int init(void)
 
     tmp = getConfString(nc_state.configFiles, 2, "VNET_MODE");
     if (!tmp) {
-        LOGWARN("VNET_MODE is not defined, defaulting to '%s'\n", NETMODE_MANAGED_NOVLAN);
-        tmp = strdup(NETMODE_MANAGED_NOVLAN);
+        LOGWARN("VNET_MODE is not defined, defaulting to '%s'\n", NETMODE_INVALID);
+        tmp = strdup(NETMODE_INVALID);
         if (!tmp) {
             LOGFATAL("Out of memory\n");
             return (EUCA_FATAL_ERROR);


### PR DESCRIPTION
set default value of VNET_MODE configuration value to be INVALID to force configuration.