### PR TITLE
EUCA-12174 Allow anonymous to create objects but deny anonymous from creating buckets

### DIFF
--- a/clc/modules/msgs/src/main/java/com/eucalyptus/auth/Accounts.java
+++ b/clc/modules/msgs/src/main/java/com/eucalyptus/auth/Accounts.java
@@ -80,6 +80,7 @@ import com.eucalyptus.auth.principal.BaseOpenIdConnectProvider;
 import com.eucalyptus.auth.principal.BaseRole;
 import com.eucalyptus.auth.principal.InstanceProfile;
 import com.eucalyptus.auth.principal.OpenIdConnectProvider;
+import com.eucalyptus.auth.principal.Principals;
 import com.eucalyptus.auth.principal.Role;
 import com.eucalyptus.auth.principal.SecurityTokenContent;
 import com.eucalyptus.auth.principal.User;
@@ -249,7 +250,11 @@ public class Accounts {
 
   @Nonnull
   public static UserPrincipal lookupPrincipalByCanonicalId( String canonicalId ) throws AuthException {
-    return getIdentityProvider( ).lookupPrincipalByCanonicalId( canonicalId );
+    if (canonicalId.equals(AccountIdentifiers.NOBODY_CANONICAL_ID)) {
+      return Principals.nobodyUser();
+    } else {
+      return getIdentityProvider( ).lookupPrincipalByCanonicalId( canonicalId );
+    }
   }
 
   @Nonnull

--- a/clc/modules/msgs/src/main/java/com/eucalyptus/auth/principal/AccountIdentifiers.java
+++ b/clc/modules/msgs/src/main/java/com/eucalyptus/auth/principal/AccountIdentifiers.java
@@ -28,6 +28,7 @@ import com.google.common.base.Function;
 public interface AccountIdentifiers {
   String NOBODY_ACCOUNT = "nobody";
   Long NOBODY_ACCOUNT_ID = 1l;
+  String NOBODY_CANONICAL_ID = "65a011a29cdf8ec533ec3d1ccaae921c"; // Matches AWS magic number
 
   /**
    * <h2>NOTE:GRZE:</h2> there will <b>always</b> be an account named <tt>eucalyptus</tt>. The name is used
@@ -39,6 +40,8 @@ public interface AccountIdentifiers {
   String SYSTEM_ACCOUNT = "eucalyptus";
   String SYSTEM_ACCOUNT_PREFIX = "(eucalyptus)";
   Long SYSTEM_ACCOUNT_ID = 0l;
+  String SYSTEM_CANONICAL_ID = ""; // Should never be used as a lookup key;
+  
   //EUCA-9376 - Workaround to avoid multiple admin users in the blockstorage account due to EUCA-9635
   String BLOCKSTORAGE_SYSTEM_ACCOUNT = SYSTEM_ACCOUNT_PREFIX + "blockstorage";
 
@@ -70,6 +73,10 @@ public interface AccountIdentifiers {
       return StringProperties.NUMBER;
     }
 
+    public static Function<AccountIdentifiers,String> accountCanonicalId( ) {
+      return StringProperties.CANONICAL_ID;
+    }
+
     private enum StringProperties implements Function<AccountIdentifiers,String> {
       NUMBER {
         @Nonnull
@@ -78,6 +85,13 @@ public interface AccountIdentifiers {
           return accountIdentifiers.getAccountNumber( );
         }
       },
+      CANONICAL_ID {
+        @Nonnull
+        @Override
+        public String apply( final AccountIdentifiers accountIdentifiers ) {
+          return accountIdentifiers.getCanonicalId( );
+        }
+      }
     }
   }
 }

--- a/clc/modules/msgs/src/main/java/com/eucalyptus/auth/principal/Principals.java
+++ b/clc/modules/msgs/src/main/java/com/eucalyptus/auth/principal/Principals.java
@@ -375,12 +375,24 @@ public class Principals {
                                                 }
                                               };
 
-  private static final AccountIdentifiers NOBODY_ACCOUNT = new SystemAccount( AccountIdentifiers.NOBODY_ACCOUNT_ID, AccountIdentifiers.NOBODY_ACCOUNT );
-  private static final AccountIdentifiers SYSTEM_ACCOUNT = new SystemAccount( AccountIdentifiers.SYSTEM_ACCOUNT_ID, AccountIdentifiers.SYSTEM_ACCOUNT );
+  private static final AccountIdentifiers NOBODY_ACCOUNT = 
+      new SystemAccount( 
+          AccountIdentifiers.NOBODY_ACCOUNT_ID, 
+          AccountIdentifiers.NOBODY_ACCOUNT,
+          AccountIdentifiers.NOBODY_CANONICAL_ID
+          );
+  private static final AccountIdentifiers SYSTEM_ACCOUNT = 
+      new SystemAccount( 
+          AccountIdentifiers.SYSTEM_ACCOUNT_ID, 
+          AccountIdentifiers.SYSTEM_ACCOUNT,
+          AccountIdentifiers.SYSTEM_CANONICAL_ID
+          );
 
   private static final Set<AccountIdentifiers> FAKE_ACCOUNTS        = ImmutableSet.of( systemAccount(), nobodyAccount() );
   private static final Set<String>  FAKE_ACCOUNT_NUMBERS =
       ImmutableSet.copyOf( Iterables.transform(FAKE_ACCOUNTS, AccountIdentifiers.Properties.accountNumber( ) ) );
+  private static final Set<String>  FAKE_CANONICAL_IDS =
+      ImmutableSet.copyOf( Iterables.transform(FAKE_ACCOUNTS, AccountIdentifiers.Properties.accountCanonicalId( ) ) );
   private static final Set<SystemUser> FAKE_USERS         = ImmutableSet.of( systemUser(), nobodyUser() );
   private static final Set<String>  FAKE_USER_IDS        =
       ImmutableSet.copyOf( Iterables.transform(FAKE_USERS, Accounts.toUserId() ) );
@@ -416,6 +428,10 @@ public class Principals {
     return FAKE_ACCOUNT_NUMBERS.contains( id );
   }
 
+  public static boolean isFakeIdentityCanonicalId( final String id ) {
+    return FAKE_CANONICAL_IDS.contains( id );
+  }
+
   public static boolean isFakeIdentityUserId( final String id ) {
     return FAKE_USER_IDS.contains( id );
   }
@@ -423,6 +439,7 @@ public class Principals {
   public static boolean isFakeIdentify( String id ) {
     return
         isFakeIdentityAccountNumber( id ) ||
+        isFakeIdentityCanonicalId( id ) ||
         isFakeIdentityUserId( id );
   }
 
@@ -446,16 +463,14 @@ public class Principals {
   private static class SystemAccount implements AccountIdentifiers {
     private final Long accountId;
     private final String accountAlias;
+    private final String canonicalId;
 
     private SystemAccount( final Long accountId,
-                           final String accountAlias ) {
+                           final String accountAlias,
+                           final String canonicalId) {
       this.accountId = accountId;
       this.accountAlias = accountAlias;
-    }
-
-    @Override
-    public String getCanonicalId() {
-          return ""; // TODO need to calculate a canonical ID
+      this.canonicalId = canonicalId;
     }
 
     @Override
@@ -466,6 +481,11 @@ public class Principals {
     @Override
     public String getAccountAlias( ) {
       return accountAlias;
+    }
+
+    @Override
+    public String getCanonicalId() {
+          return canonicalId;
     }
 
   }

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageGateway.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageGateway.java
@@ -630,6 +630,12 @@ public class ObjectStorageGateway implements ObjectStorageService {
         throw new InvalidBucketNameException(request.getBucket());
       }
 
+      if (Principals.isFakeIdentify(canonicalId)) {
+        LOG.error("CorrelationId: " + request.getCorrelationId() + " Create bucket " + request.getBucket()
+        + " access is denied because the request's user ID is not allowed to create buckets.");
+        throw new AccessDeniedException(request.getBucket());
+      }
+      
       final AccessControlPolicy acPolicy = getFullAcp(request.getAccessControlList(), requestUser, null);
       Bucket bucket = Bucket.getInitializedBucket(request.getBucket(), requestUser.getUserId(), acPolicy, request.getLocationConstraint());
 


### PR DESCRIPTION
Also added the special canonical ID for the anonymous user that AWS defines.
@sjones4 @euca-nightfury please review if you can.
