### PR TITLE
EUCA-12902 Refactored handling of anonymous/nobody requests

### DIFF
--- a/clc/modules/msgs/src/main/java/com/eucalyptus/auth/Accounts.java
+++ b/clc/modules/msgs/src/main/java/com/eucalyptus/auth/Accounts.java
@@ -188,6 +188,7 @@ public class Accounts {
   }
 
   public static String lookupAccountIdByCanonicalId( String canonicalId ) throws AuthException {
+    throwIfFakeIdentity( canonicalId );
     return getIdentityProvider( ).lookupAccountIdentifiersByCanonicalId( canonicalId ).getAccountNumber();
   }
 
@@ -208,6 +209,7 @@ public class Accounts {
   }
 
   public static AccountIdentifiers lookupAccountIdentifiersByCanonicalId( final String canonicalId ) throws AuthException {
+    throwIfFakeIdentity( canonicalId );
     return Accounts.getIdentityProvider( ).lookupAccountIdentifiersByCanonicalId( canonicalId );
   }
 
@@ -250,11 +252,8 @@ public class Accounts {
 
   @Nonnull
   public static UserPrincipal lookupPrincipalByCanonicalId( String canonicalId ) throws AuthException {
-    if (canonicalId.equals(AccountIdentifiers.NOBODY_CANONICAL_ID)) {
-      return Principals.nobodyUser();
-    } else {
-      return getIdentityProvider( ).lookupPrincipalByCanonicalId( canonicalId );
-    }
+    throwIfFakeIdentity( canonicalId );
+    return getIdentityProvider( ).lookupPrincipalByCanonicalId( canonicalId );
   }
 
   @Nonnull
@@ -463,6 +462,12 @@ public class Accounts {
     return idSuffix;
   }
 
+  private static void throwIfFakeIdentity( final String id ) throws AuthException {
+    if ( Principals.isFakeIdentify( id ) ) {
+      throw new AuthException( "Invalid identity: " + id );
+    }
+  }
+  
   private enum UserStringProperties implements Function<User,String> {
     ACCOUNT_NUMBER {
       @Override

--- a/clc/modules/msgs/src/main/java/com/eucalyptus/auth/principal/AccountIdentifiers.java
+++ b/clc/modules/msgs/src/main/java/com/eucalyptus/auth/principal/AccountIdentifiers.java
@@ -26,9 +26,7 @@ import com.google.common.base.Function;
  *
  */
 public interface AccountIdentifiers {
-  // Alias (display) name "anonymous" which is the AWS term, not "nobody" which is an internal Euaclyptus 
-  // term that we never show users and AWS never uses.
-  String NOBODY_ACCOUNT = "anonymous";
+  String NOBODY_ACCOUNT = "nobody";
   Long NOBODY_ACCOUNT_ID = 1l;
   String NOBODY_CANONICAL_ID = "65a011a29cdf8ec533ec3d1ccaae921c"; // Matches AWS magic number
 
@@ -42,7 +40,7 @@ public interface AccountIdentifiers {
   String SYSTEM_ACCOUNT = "eucalyptus";
   String SYSTEM_ACCOUNT_PREFIX = "(eucalyptus)";
   Long SYSTEM_ACCOUNT_ID = 0l;
-  String SYSTEM_CANONICAL_ID = ""; // Should never be used as a lookup key;
+  String SYSTEM_CANONICAL_ID = "0"; // Should never be used as a lookup key;
   
   //EUCA-9376 - Workaround to avoid multiple admin users in the blockstorage account due to EUCA-9635
   String BLOCKSTORAGE_SYSTEM_ACCOUNT = SYSTEM_ACCOUNT_PREFIX + "blockstorage";

--- a/clc/modules/msgs/src/main/java/com/eucalyptus/auth/principal/AccountIdentifiers.java
+++ b/clc/modules/msgs/src/main/java/com/eucalyptus/auth/principal/AccountIdentifiers.java
@@ -26,7 +26,9 @@ import com.google.common.base.Function;
  *
  */
 public interface AccountIdentifiers {
-  String NOBODY_ACCOUNT = "nobody";
+  // Alias (display) name "anonymous" which is the AWS term, not "nobody" which is an internal Euaclyptus 
+  // term that we never show users and AWS never uses.
+  String NOBODY_ACCOUNT = "anonymous";
   Long NOBODY_ACCOUNT_ID = 1l;
   String NOBODY_CANONICAL_ID = "65a011a29cdf8ec533ec3d1ccaae921c"; // Matches AWS magic number
 

--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/entities/S3AccessControlledEntity.java
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/entities/S3AccessControlledEntity.java
@@ -318,7 +318,7 @@ public abstract class S3AccessControlledEntity<STATE extends Enum<STATE>> extend
           grantee.setType("Group");
         } else {
           try {
-            displayName = Accounts.lookupAccountIdentifiersByCanonicalId(entry.getKey()).getAccountAlias();
+            displayName = AclUtils.lookupDisplayNameByCanonicalId(entry.getKey());
           } catch (AuthException e) {
             // Not found
             displayName = "";
@@ -367,7 +367,7 @@ public abstract class S3AccessControlledEntity<STATE extends Enum<STATE>> extend
 
       // Check for valid owner
       try {
-        Accounts.lookupPrincipalByCanonicalId(ownerCanonicalId);
+        AclUtils.lookupPrincipalByCanonicalId(ownerCanonicalId);
       } catch (Exception e) {
         // Invalid owner
         LOG.warn("Got invalid owner in AccessControlPolicy during mapping to DB: " + ownerCanonicalId);

--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/util/AclUtils.java
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/util/AclUtils.java
@@ -1,5 +1,4 @@
 /*************************************************************************
- * Copyright 2009-2015 Eucalyptus Systems, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -200,7 +199,7 @@ public class AclUtils {
       }
 
       try {
-        displayName = Accounts.lookupAccountIdentifiersByCanonicalId(ownerCanonicalId).getAccountAlias();
+        displayName = lookupDisplayNameByCanonicalId(ownerCanonicalId);
       } catch (AuthException e) {
         displayName = "";
       }
@@ -322,7 +321,7 @@ public class AclUtils {
       String canonicalId = ownerIds.getBucketOwnerCanonicalId();
       String displayName = "";
       try {
-        displayName = Accounts.lookupAccountIdentifiersByCanonicalId(canonicalId).getAccountAlias();
+        displayName = lookupDisplayNameByCanonicalId(canonicalId);
       } catch (AuthException e) {
         displayName = "";
       }
@@ -348,7 +347,7 @@ public class AclUtils {
       String canonicalId = ownerIds.getBucketOwnerCanonicalId();
       String displayName = "";
       try {
-        displayName = Accounts.lookupAccountIdentifiersByCanonicalId(canonicalId).getAccountAlias();
+        displayName = lookupDisplayNameByCanonicalId(canonicalId);
       } catch (AuthException e) {
         displayName = "";
       }
@@ -565,7 +564,7 @@ public class AclUtils {
     @Override
     public String check(String id) {
       try {
-        UserPrincipal userPrincipal = Accounts.lookupPrincipalByCanonicalId( id );
+        UserPrincipal userPrincipal = lookupPrincipalByCanonicalId( id );
         return userPrincipal.getCanonicalId();
       } catch (AuthException authEx) {
       }
@@ -611,5 +610,22 @@ public class AclUtils {
     }
     return null;
   }
+
+  private static String lookupDisplayNameByCanonicalId( final String canonicalId ) throws AuthException {
+    if ( AccountIdentifiers.NOBODY_CANONICAL_ID.equals( canonicalId ) ) {
+      return Principals.nobodyAccount( ).getAccountAlias( );
+    } else {
+      return Accounts.lookupAccountIdentifiersByCanonicalId( canonicalId ).getAccountAlias();
+    }
+  }
+  
+  private static UserPrincipal lookupPrincipalByCanonicalId( final String canonicalId ) throws AuthException {
+    if ( AccountIdentifiers.NOBODY_CANONICAL_ID.equals( canonicalId ) ) {
+      return Principals.nobodyUser();
+    } else {
+      return Accounts.lookupPrincipalByCanonicalId( canonicalId );
+    }
+  }
+  
 
 }

--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/util/AclUtils.java
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/util/AclUtils.java
@@ -611,7 +611,7 @@ public class AclUtils {
     return null;
   }
 
-  private static String lookupDisplayNameByCanonicalId( final String canonicalId ) throws AuthException {
+  public static String lookupDisplayNameByCanonicalId( final String canonicalId ) throws AuthException {
     if ( AccountIdentifiers.NOBODY_CANONICAL_ID.equals( canonicalId ) ) {
       return Principals.nobodyAccount( ).getAccountAlias( );
     } else {
@@ -619,8 +619,9 @@ public class AclUtils {
     }
   }
   
-  private static UserPrincipal lookupPrincipalByCanonicalId( final String canonicalId ) throws AuthException {
+  public static UserPrincipal lookupPrincipalByCanonicalId( final String canonicalId ) throws AuthException {
     if ( AccountIdentifiers.NOBODY_CANONICAL_ID.equals( canonicalId ) ) {
+      LOG.info("Looked up nobody by canonical ID " + canonicalId);
       return Principals.nobodyUser();
     } else {
       return Accounts.lookupPrincipalByCanonicalId( canonicalId );

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageGateway.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageGateway.java
@@ -630,12 +630,6 @@ public class ObjectStorageGateway implements ObjectStorageService {
         throw new InvalidBucketNameException(request.getBucket());
       }
 
-      if (Principals.isFakeIdentify(canonicalId)) {
-        LOG.error("CorrelationId: " + request.getCorrelationId() + " Create bucket " + request.getBucket()
-        + " access is denied because the request's user ID is not allowed to create buckets.");
-        throw new AccessDeniedException(request.getBucket());
-      }
-      
       final AccessControlPolicy acPolicy = getFullAcp(request.getAccessControlList(), requestUser, null);
       Bucket bucket = Bucket.getInitializedBucket(request.getBucket(), requestUser.getUserId(), acPolicy, request.getLocationConstraint());
 
@@ -689,7 +683,7 @@ public class ObjectStorageGateway implements ObjectStorageService {
         }
       } else {
         LOG.error("CorrelationId: " + request.getCorrelationId() + " Create bucket " + request.getBucket()
-            + " access is denied based on acl and/or IAM policy");
+            + " access is denied based on ACL and/or IAM policy");
         throw new AccessDeniedException(request.getBucket());
       }
     } catch (AccessDeniedException e) {


### PR DESCRIPTION
See comments in https://github.com/eucalyptus/eucalyptus/pull/82

Refactoring and further fixes made per the review there.

Quota checking for anonymous object creations are being investigated along with https://eucalyptus.atlassian.net/browse/EUCA-12617 "S3 quotas not enforced for copy object".

If I see a problem, I'll open a new EUCA- issue for anonymous quotas and fix it there, along with fixing EUCA-12617.

@sjones4 and @euca-nightfury if you're OK with these changes, I will commit them to maint-4.4.
Thanks in advance for your review!
