### PR TITLE
EUCA-13114 Serialize Ceph snapshot creations per-volume, and limit all back-end snapshot concurrency

### DIFF
--- a/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/BlockStorageController.java
+++ b/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/BlockStorageController.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2014 Eucalyptus Systems, Inc.
+ * (c) Copyright 2016 Hewlett Packard Enterprise Development Company LP
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -12,11 +12,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
- *
- * Please contact Eucalyptus Systems, Inc., 6755 Hollister Ave., Goleta
- * CA 93117, USA or visit http://www.eucalyptus.com/licenses/ if you need
- * additional information or have any questions.
- *
+ * 
  * This file may incorporate work covered under the following copyright
  * and permission notice:
  *
@@ -816,12 +812,9 @@ public class BlockStorageController implements BlockStorageService {
           String snapPointId = null;
           try {
             // This will be a no-op if the backend doesn't support it. Will return null.
-            // TODO is it worth synchronizing snapshot point creation for a volume
-            synchronized (volumeId) {
-              snapPointId = blockManager.createSnapshotPoint(volumeId, snapshotId);
-              // Start time is the time of snapshot point creation
-              snapshotInfo.setStartTime(new Date());
-            }
+            snapPointId = blockManager.createSnapshotPoint(volumeId, snapshotId);
+            // Start time is the time of snapshot point creation
+            snapshotInfo.setStartTime(new Date());
             if (snapPointId == null) {
               LOG.debug("Synchronous snap point not supported for this backend. Cleanly skipped.");
             } else {

--- a/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/async/SnapshotCreator.java
+++ b/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/async/SnapshotCreator.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2015 Eucalyptus Systems, Inc.
+ * (c) Copyright 2016 Hewlett Packard Enterprise Development Company LP
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -12,10 +12,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
- *
- * Please contact Eucalyptus Systems, Inc., 6755 Hollister Ave., Goleta
- * CA 93117, USA or visit http://www.eucalyptus.com/licenses/ if you need
- * additional information or have any questions.
  *
  * This file may incorporate work covered under the following copyright
  * and permission notice:
@@ -142,6 +138,7 @@ public class SnapshotCreator implements Runnable {
 
   @Override
   public void run() {
+    LOG.trace("Starting SnapshotCreator task");
     EucaSemaphore semaphore = EucaSemaphoreDirectory.getSolitarySemaphore(volumeId);
     try {
       Boolean shouldTransferSnapshots = true;
@@ -319,6 +316,7 @@ public class SnapshotCreator implements Runnable {
         LOG.warn("Cannot update " + snapshotId + " status to failed on SC", e);
       }
     }
+    LOG.trace("Finished SnapshotCreator task");
   }
 
   /*

--- a/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/async/ThreadPoolSizeUpdater.java
+++ b/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/async/ThreadPoolSizeUpdater.java
@@ -1,3 +1,19 @@
+/*************************************************************************
+ * (c) Copyright 2016 Hewlett Packard Enterprise Development Company LP
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ ************************************************************************/
+
 package com.eucalyptus.blockstorage.async;
 
 import java.util.concurrent.TimeUnit;
@@ -36,16 +52,19 @@ public class ThreadPoolSizeUpdater extends CheckerTask {
 
       Integer currentSize = VolumeThreadPool.getPoolSize();
       if (currentSize != null && info.getMaxConcurrentVolumes() != null && currentSize != info.getMaxConcurrentVolumes()) {
+        LOG.debug("Updating VolumeThreadPool to " + info.getMaxConcurrentVolumes());
         VolumeThreadPool.updatePoolSize(info.getMaxConcurrentVolumes());
       }
 
       currentSize = SnapshotThreadPool.getPoolSize();
       if (currentSize != null && info.getMaxConcurrentSnapshots() != null && currentSize != info.getMaxConcurrentSnapshots()) {
+        LOG.debug("Updating SnapshotThreadPool to " + info.getMaxConcurrentSnapshots());
         SnapshotThreadPool.updatePoolSize(info.getMaxConcurrentSnapshots());
       }
 
       currentSize = SnapshotTransferThreadPool.getPoolSize();
       if (currentSize != null && info.getMaxConcurrentSnapshotTransfers() != null && currentSize != info.getMaxConcurrentSnapshotTransfers()) {
+        LOG.debug("Updating SnapshotTransferThreadPool to " + info.getMaxConcurrentSnapshotTransfers());
         SnapshotTransferThreadPool.updatePoolSize(info.getMaxConcurrentSnapshotTransfers());
       }
     } catch (Throwable t) {

--- a/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/ceph/CephRbdProvider.java
+++ b/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/ceph/CephRbdProvider.java
@@ -395,14 +395,16 @@ public class CephRbdProvider implements SANProvider {
       // because Ceph sometimes has failures, see EUCA-13114
       EucaSemaphore semaphore = EucaSemaphoreDirectory.getSolitarySemaphore(SEMAPHORE_PREFIX + parentVolumeId);
       try {
-        try {
-          semaphore.acquire();
-        } catch (InterruptedException ex) {
-          throw new EucalyptusCloudException("Failed to create snapshot point " + snapshotId + " on volume " + parentVolumeId +
-              " as the semaphore could not be acquired");
-        }
+        semaphore.acquire();
+        LOG.trace("Acquired semaphore for Ceph createSnapshotPoint for volume " + parentVolumeId);
+      } catch (InterruptedException ex) {
+        throw new EucalyptusCloudException("Failed to create snapshot point " + snapshotId + " on volume " + parentVolumeId +
+            " as the semaphore could not be acquired");
+      }
+      try {
         snapshotPointId = rbdService.createSnapshot(parentVolumeId, snapshotPoint, parent.getPool());
       } finally {
+        LOG.trace("Releasing semaphore for Ceph createSnapshotPoint for volume " + parentVolumeId);
         semaphore.release();
       }
       LOG.info("Created snapshot point parentVolumeId=" + parentVolumeId + ", snapshotId=" + snapshotId + ", parentVolumeIqn=" + parentVolumeIqn);

--- a/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/ceph/CephRbdProvider.java
+++ b/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/ceph/CephRbdProvider.java
@@ -391,7 +391,8 @@ public class CephRbdProvider implements SANProvider {
     if (parent != null && !Strings.isNullOrEmpty(parent.getPool())) {
       String snapshotPoint = CephRbdInfo.SNAPSHOT_FOR_PREFIX + snapshotId;
       String snapshotPointId = null;
-      // Don't allow >1 snapshot on the same volume, because Ceph sometimes has failures, EUCA-13114
+      // Don't allow >1 concurrent snapshot operation on the same volume, 
+      // because Ceph sometimes has failures, see EUCA-13114
       EucaSemaphore semaphore = EucaSemaphoreDirectory.getSolitarySemaphore(SEMAPHORE_PREFIX + parentVolumeId);
       try {
         try {

--- a/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/ceph/CephRbdProvider.java
+++ b/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/ceph/CephRbdProvider.java
@@ -399,7 +399,7 @@ public class CephRbdProvider implements SANProvider {
           semaphore.acquire();
         } catch (InterruptedException ex) {
           throw new EucalyptusCloudException("Failed to create snapshot point " + snapshotId + " on volume " + parentVolumeId +
-              "as the semaphore could not be acquired");
+              " as the semaphore could not be acquired");
         }
         snapshotPointId = rbdService.createSnapshot(parentVolumeId, snapshotPoint, parent.getPool());
       } finally {


### PR DESCRIPTION
See EUCA-13114 for details.

Because Ceph has occasional failures performing >1 snapshot on the same Ceph image (Euca volume), added semaphore logic to only allow one at a time, per volume. 

For all back-ends except DAS and Overlay, Euca takes a snapshot point on the back-end volume before using that snapshot to create the Euca snapshot stored in OSG (full or delta). That snapshot point creation was not honoring the property [ZONE].storage.maxconcurrentsnapshots, although the rest of the snapshotting process did. So the concurrency of that back-end snapshot point creation was unlimited. Added semaphore logic to limit those snapshots in progress at a time to this property value.
