### PR TITLE
EUCA-13213 EUCA-13244 Wait for previous snapshot etc.

### DIFF
--- a/clc/modules/block-storage-common/src/main/java/com/eucalyptus/blockstorage/ceph/CanonicalRbdObject.java
+++ b/clc/modules/block-storage-common/src/main/java/com/eucalyptus/blockstorage/ceph/CanonicalRbdObject.java
@@ -98,7 +98,9 @@ public class CanonicalRbdObject {
           return null;
         }
       } else {
-        LOG.warn("Invalid canonical ID " + canonicalId);
+        // Caller may pass in a null ID which may be OK.
+        // If not, errors will be handled at a higher level.
+        LOG.debug("Invalid canonical ID " + canonicalId);
         return null;
       }
     } catch (Exception e) {

--- a/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/S3SnapshotTransfer.java
+++ b/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/S3SnapshotTransfer.java
@@ -758,7 +758,7 @@ public class S3SnapshotTransfer implements SnapshotTransfer {
 
   private S3Object download() throws SnapshotTransferException {
     try {
-      LOG.debug("Dowloading snapshot from objectstorage: snapshotId=" + snapshotId + ", bucket=" + bucketName + ", key=" + keyName);
+      LOG.debug("Downloading snapshot from objectstorage: snapshotId=" + snapshotId + ", bucket=" + bucketName + ", key=" + keyName);
       return retryAfterRefresh(new Function<GetObjectRequest, S3Object>() {
 
         @Override

--- a/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/async/FailedSnapshotCleaner.java
+++ b/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/async/FailedSnapshotCleaner.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2015 Eucalyptus Systems, Inc.
+ * (c) Copyright 2017 Hewlett Packard Enterprise Development Company LP
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -12,11 +12,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
- *
- * Please contact Eucalyptus Systems, Inc., 6755 Hollister Ave., Goleta
- * CA 93117, USA or visit http://www.eucalyptus.com/licenses/ if you need
- * additional information or have any questions.
- *
+ * 
  * This file may incorporate work covered under the following copyright
  * and permission notice:
  *
@@ -134,7 +130,7 @@ public class FailedSnapshotCleaner extends CheckerTask {
 
     // Disconnect snapshot from SC
     try {
-      LOG.info("Disconnecting snapshot " + snapshotId + " from the Storage Controller");
+      LOG.debug("Disconnecting snapshot " + snapshotId + " from the Storage Controller");
       blockManager.finishVolume(snapshotId);
     } catch (Exception e) {
       LOG.debug("Attempt to disconnect snapshot " + snapshotId + " from Storage Controller failed because: " + e.getMessage());
@@ -142,7 +138,7 @@ public class FailedSnapshotCleaner extends CheckerTask {
 
     // Delete snapshot from backend
     try {
-      LOG.info("Cleaning snapshot " + snapshotId + " on storage backend");
+      LOG.debug("Cleaning snapshot " + snapshotId + " on storage backend");
       blockManager.cleanSnapshot(snapshotId, snapInfo.getSnapPointId());
     } catch (Exception e) {
       LOG.debug("Attempt to clean snapshot " + snapshotId + " on storage backend failed because: " + e.getMessage());
@@ -151,7 +147,7 @@ public class FailedSnapshotCleaner extends CheckerTask {
     // Delete snapshot from OSG
     try {
       if (!Strings.isNullOrEmpty(snapInfo.getSnapshotLocation())) {
-        LOG.info("Deleting snapshot " + snapshotId + " from objectsotrage");
+        LOG.debug("Deleting snapshot " + snapshotId + " from objectsotrage");
         if (snapshotTransfer == null) {
           snapshotTransfer = new S3SnapshotTransfer();
         }

--- a/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/async/FailedVolumeCleaner.java
+++ b/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/async/FailedVolumeCleaner.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2015 Eucalyptus Systems, Inc.
+ * (c) Copyright 2017 Hewlett Packard Enterprise Development Company LP
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -12,11 +12,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
- *
- * Please contact Eucalyptus Systems, Inc., 6755 Hollister Ave., Goleta
- * CA 93117, USA or visit http://www.eucalyptus.com/licenses/ if you need
- * additional information or have any questions.
- *
+ * 
  * This file may incorporate work covered under the following copyright
  * and permission notice:
  *
@@ -121,7 +117,7 @@ public class FailedVolumeCleaner extends CheckerTask {
 
   private void cleanVolume(VolumeInfo volumeInfo) {
     String volumeId = volumeInfo.getVolumeId();
-    LOG.debug("Cleaning failed volume " + volumeInfo.getVolumeId());
+    LOG.info("Cleaning up failed volume " + volumeInfo.getVolumeId());
 
     try {
       blockManager.cleanVolume(volumeId);

--- a/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/async/SnapshotCreator.java
+++ b/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/async/SnapshotCreator.java
@@ -143,7 +143,7 @@ public class SnapshotCreator implements Runnable {
   @Override
   public void run() {
     LOG.trace("Starting SnapshotCreator task");
-    EucaSemaphore semaphore = EucaSemaphoreDirectory.getSolitarySemaphore(volumeId);
+    EucaSemaphore semaphore = EucaSemaphoreDirectory.getSolitarySemaphore(this.volumeId);
     try {
       Boolean shouldTransferSnapshots = true;
       // SnapshotTransfer snapshotTransfer = null;
@@ -157,12 +157,12 @@ public class SnapshotCreator implements Runnable {
         // Prepare for the snapshot upload (fetch credentials for snapshot upload to osg, create the bucket). Error out if this fails without
         // creating the snapshot on the blockstorage backend
         if (null == snapshotTransfer) {
-          snapshotTransfer = new S3SnapshotTransfer(snapshotId, snapshotId);
+          snapshotTransfer = new S3SnapshotTransfer(this.snapshotId, this.snapshotId);
         }
         bucket = snapshotTransfer.prepareForUpload();
 
         if (snapshotTransfer == null || StringUtils.isBlank(bucket)) {
-          throw new EucalyptusCloudException("Failed to initialize snapshot transfer mechanism for uploading " + snapshotId);
+          throw new EucalyptusCloudException("Failed to initialize snapshot transfer mechanism for uploading " + this.snapshotId);
         }
       }
 
@@ -171,13 +171,13 @@ public class SnapshotCreator implements Runnable {
         try {
           semaphore.acquire();
         } catch (InterruptedException ex) {
-          throw new EucalyptusCloudException("Failed to create snapshot " + snapshotId + " as the semaphore could not be acquired");
+          throw new EucalyptusCloudException("Failed to create snapshot " + this.snapshotId + " as the semaphore could not be acquired");
         }
 
         // Check to ensure that a failed/cancellation has not be set
-        if (!isSnapshotMarkedFailed(snapshotId)) {
+        if (!isSnapshotMarkedFailed(this.snapshotId)) {
           if (null == progressCallback) {
-            progressCallback = new SnapshotProgressCallback(snapshotId); // Setup the progress callback, that should start the progress
+            progressCallback = new SnapshotProgressCallback(this.snapshotId); // Setup the progress callback, that should start the progress
           }
           blockManager.createSnapshot(this.volumeId, this.snapshotId, this.snapPointId);
           progressCallback.updateBackendProgress(50); // to indicate that backend snapshot process is 50% done
@@ -188,16 +188,17 @@ public class SnapshotCreator implements Runnable {
         semaphore.release();
       }
 
+      SnapshotInfo prevSnap = null;
+      SnapshotInfo currSnap = null;
+
       Future<String> uploadFuture = null;
-      if (!isSnapshotMarkedFailed(snapshotId)) {
+      if (!isSnapshotMarkedFailed(this.snapshotId)) {
+
         if (shouldTransferSnapshots) {
           // TODO move this check down further
 
           // generate snapshot location
-          String snapshotLocation = SnapshotInfo.generateSnapshotLocationURI(SnapshotTransferConfiguration.OSG, bucket, snapshotId);
-
-          SnapshotInfo prevSnap = null;
-          SnapshotInfo currSnap = null;
+          String snapshotLocation = SnapshotInfo.generateSnapshotLocationURI(SnapshotTransferConfiguration.OSG, bucket, this.snapshotId);
 
           // gather what needs to be uploaded
           try {
@@ -220,7 +221,7 @@ public class SnapshotCreator implements Runnable {
                     try {
                       prevSnapSemaphore.acquire();
                     } catch (InterruptedException ex) {
-                      LOG.warn("Cannot update metadata for snapshot " + snapshotId + " due to an error acquiring semaphore for a previous snapshot "
+                      LOG.warn("Cannot update metadata for snapshot " + this.snapshotId + " due to an error acquiring semaphore for a previous snapshot "
                           + prevSnap.getSnapshotId() + ". May retry again later");
                       continue;
                     }
@@ -256,11 +257,11 @@ public class SnapshotCreator implements Runnable {
           if (prevSnap != null) {
             LOG.info("Generate delta between penultimate snapshot " + prevSnap.getSnapshotId() + " and latest snapshot " + this.snapshotId);
             srwc =
-                blockManager.prepIncrementalSnapshotForUpload(volumeId, snapshotId, snapPointId, prevSnap.getSnapshotId(), prevSnap.getSnapPointId());
+                blockManager.prepIncrementalSnapshotForUpload(this.volumeId, this.snapshotId, this.snapPointId, prevSnap.getSnapshotId(), prevSnap.getSnapPointId());
             snapshotResource = srwc.getSr();
           } else {
             LOG.info("Upload entire content of snapshot " + this.snapshotId);
-            snapshotResource = blockManager.prepSnapshotForUpload(volumeId, snapshotId, snapPointId);
+            snapshotResource = blockManager.prepSnapshotForUpload(this.volumeId, this.snapshotId, this.snapPointId);
           }
 
           if (snapshotResource == null) {
@@ -271,7 +272,7 @@ public class SnapshotCreator implements Runnable {
           try {
             uploadFuture = snapshotTransfer.upload(snapshotResource, progressCallback);
           } catch (Exception e) {
-            throw new EucalyptusCloudException("Failed to upload snapshot " + snapshotId + " to objectstorage", e);
+            throw new EucalyptusCloudException("Failed to upload snapshot " + this.snapshotId + " to objectstorage", e);
           }
 
           if (srwc != null && srwc.getCallback() != null) {
@@ -289,56 +290,137 @@ public class SnapshotCreator implements Runnable {
 
       // finish the snapshot on backend - sever iscsi connection, disconnect and wait for it to complete
       try {
-        LOG.debug("Finishing up " + snapshotId + " on block storage backend");
-        blockManager.finishVolume(snapshotId);
-        LOG.info("Finished creating " + snapshotId + " on block storage backend");
+        LOG.debug("Finishing up " + this.snapshotId + " on block storage backend");
+        blockManager.finishVolume(this.snapshotId);
+        LOG.info("Finished creating " + this.snapshotId + " on block storage backend");
         progressCallback.updateBackendProgress(50); // to indicate that backend snapshot process is 50% done
       } catch (EucalyptusCloudException ex) {
-        LOG.warn("Failed to complete snapshot " + snapshotId + " on backend", ex);
+        LOG.warn("Failed to complete snapshot " + this.snapshotId + " on backend", ex);
         throw ex;
       }
 
       // If uploading, wait for upload to complete
       if (uploadFuture != null) {
-        LOG.debug("Waiting for upload of " + snapshotId + " to complete");
+        LOG.debug("Waiting for upload of " + this.snapshotId + " to complete");
         if (uploadFuture.get() != null) {
-          LOG.info("Uploaded " + snapshotId + " to object storage gateway, etag result - " + uploadFuture.get());
+          LOG.info("Uploaded " + this.snapshotId + " to object storage gateway, etag result - " + uploadFuture.get());
         } else {
-          LOG.warn("Failed to upload " + snapshotId + " to object storage gateway failed. Check prior logs for exact errors");
-          throw new EucalyptusCloudException("Failed to upload " + snapshotId + " to object storage gateway");
+          LOG.warn("Failed to upload " + this.snapshotId + " to object storage gateway failed. Check prior logs for exact errors");
+          throw new EucalyptusCloudException("Failed to upload " + this.snapshotId + " to object storage gateway");
         }
       }
 
-      // Mark snapshot as available
-      markSnapshotAvailable();
-      LOG.debug("Snapshot " + snapshotId + " set to 'available' state");
+      // Now that the snapshot is complete, if it's a delta, wait until the
+      // snapshot transfer timeout for the parent to go into a final state 
+      // (good or bad). If good, declare this snapshot available.
+      // If bad, of if it never competes, declare this snapshot failed. 
+      // (Artifacts will be cleaned up by periodic cleanup tasks.)
+      
+      if (prevSnap != null) {
+        final int MILLIS_PER_HOUR = 60 * 60 * 1000;
+        final int timeoutMillis = StorageInfo.getStorageInfo().getSnapshotTransferTimeoutInHours()
+            * MILLIS_PER_HOUR;
+        final int pollPeriodMillis = 10000; // 10 sec
+        int waitTimeSoFar = 0;
+        
+        while (!isSnapshotMarkedFinalized(prevSnap.getSnapshotId()) &&
+            waitTimeSoFar < timeoutMillis) {
+          try {
+            Thread.sleep(pollPeriodMillis);
+          } catch (InterruptedException e) {
+            throw new RuntimeException("Interrupted while waiting for previous snapshot to complete", e);
+          }
+          waitTimeSoFar += pollPeriodMillis;
+        }
+        if (isSnapshotMarkedFinalized(prevSnap.getSnapshotId())) {
+          if (isSnapshotMarkedAvailable(prevSnap.getSnapshotId())) {
+            markSnapshotAvailable();
+          } else {
+            markSnapshotFailed();
+            LOG.error("Previous snapshot " + prevSnap.getSnapshotId() + " finalized into the " +
+                prevSnap.getStatus() + " state. This snapshot delta " + this.snapshotId + 
+                " set to 'failed' state because it requires an intact previous snapshot.");
+          }
+        } else {
+          markSnapshotFailed();
+          LOG.error("Previous snapshot " + prevSnap.getSnapshotId() + " never finalized after " + 
+              "waiting " + (timeoutMillis / MILLIS_PER_HOUR) + " hours. " + 
+              "This snapshot delta " + this.snapshotId + " set to 'failed' state because " +
+              "it requires an intact previous snapshot.");
+        }
+      } else {
+        // No previous snapshot, therefore we're done
+        markSnapshotAvailable();
+        LOG.debug("Snapshot " + this.snapshotId + " set to 'available' state");
+      }
     } catch (Exception ex) {
-      LOG.error("Failed to create snapshot " + snapshotId, ex);
+      LOG.error("Failed to create snapshot " + this.snapshotId, ex);
 
       try {
         markSnapshotFailed();
-        LOG.debug("Snapshot " + snapshotId + " set to 'failed' state");
+        LOG.debug("Snapshot " + this.snapshotId + " set to 'failed' state");
       } catch (TransactionException | NoSuchElementException e) {
-        LOG.warn("Cannot update " + snapshotId + " status to failed on SC", e);
+        LOG.warn("Cannot update snapshot " + this.snapshotId + " status to 'failed' in DB", e);
       }
     }
     LOG.trace("Finished SnapshotCreator task");
   }
 
-  /*
-   * Does a check of the snapshot's status as reflected in the DB.
+  /* @return the given snapshot's info from the DB, or
+   *         null if DB entry not found
    */
-  private boolean isSnapshotMarkedFailed(String snapshotId) {
+  private SnapshotInfo getSnapshotInfo(String snapshotId) {
     try (TransactionResource tran = Entities.transactionFor(SnapshotInfo.class)) {
       tran.setRollbackOnly();
-      SnapshotInfo snap = Entities.uniqueResult(new SnapshotInfo(snapshotId));
-      if (snap != null && StorageProperties.Status.failed.toString().equals(snap.getStatus())) {
-        return true;
-      }
+      return Entities.uniqueResult(new SnapshotInfo(snapshotId));
     } catch (Exception e) {
-      LOG.error("Error determining status of snapshot " + snapshotId);
+      LOG.error("Error checking for status of snapshot " + snapshotId);
+      return null;
     }
-    return false;
+  }
+  
+  /*
+   * Does a check of the snapshot's status as reflected in the DB.
+   * @return true if snapshot is in the 'failed' state,
+   *         false otherwise
+   */
+  private boolean isSnapshotMarkedFailed(String snapshotId) {
+    SnapshotInfo snapshotInfo = getSnapshotInfo(snapshotId);
+    if (snapshotInfo != null) {
+      return StorageProperties.Status.failed.toString().equals(snapshotInfo.getStatus());
+    } else {
+      return false;
+    }
+  }
+
+  /*
+   * Does a check of the snapshot's status as reflected in the DB.
+   * @return false if snapshot is not (yet) recorded in database
+   *         or it's in the 'creating' or 'pending' state,
+   *         true otherwise
+   */
+  private boolean isSnapshotMarkedFinalized(String snapshotId) {
+    SnapshotInfo snapshotInfo = getSnapshotInfo(snapshotId);
+    if (snapshotInfo != null) {
+      return !(StorageProperties.Status.creating.toString().equals(snapshotInfo.getStatus()) ||
+          StorageProperties.Status.pending.toString().equals(snapshotInfo.getStatus()));
+    } else {
+      return false;
+    }
+  }
+
+  /*
+   * Does a check of the snapshot's status as reflected in the DB.
+   * @return true if snapshot is in the 'available' state,
+   *         false otherwise
+   */
+  private boolean isSnapshotMarkedAvailable(String snapshotId) {
+    SnapshotInfo snapshotInfo = getSnapshotInfo(snapshotId);
+    if (snapshotInfo != null) {
+      return StorageProperties.Status.available.toString().equals(snapshotInfo.getStatus());
+    } else {
+      return false;
+    }
   }
 
   private void markSnapshotAvailable() throws TransactionException, NoSuchElementException {

--- a/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/async/SnapshotDeleter.java
+++ b/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/async/SnapshotDeleter.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2015 Eucalyptus Systems, Inc.
+ * (c) Copyright 2017 Hewlett Packard Enterprise Development Company LP
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -12,11 +12,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
- *
- * Please contact Eucalyptus Systems, Inc., 6755 Hollister Ave., Goleta
- * CA 93117, USA or visit http://www.eucalyptus.com/licenses/ if you need
- * additional information or have any questions.
- *
+ * 
  * This file may incorporate work covered under the following copyright
  * and permission notice:
  *
@@ -134,7 +130,7 @@ public class SnapshotDeleter extends CheckerTask {
         for (SnapshotInfo snap : snapshotsToBeDeleted) {
           try {
             String snapshotId = snap.getSnapshotId();
-            LOG.info("Snapshot " + snapshotId + " was marked for deletion from EBS backend. Evaluating prerequistes for cleanup...");
+            LOG.debug("Snapshot " + snapshotId + " was marked for deletion from EBS backend. Evaluating prerequistes for cleanup...");
 
             if (snap.getIsOrigin() != null && snap.getIsOrigin()) { // check if snapshot originates in this az
               // acquire semaphore before deleting to avoid concurrent interaction with delta creation process
@@ -287,7 +283,7 @@ public class SnapshotDeleter extends CheckerTask {
         LOG.warn("Failed to delete snapshot " + snap.getSnapshotId() + " from ObjectStorageGateway", e);
       }
     } else {
-      LOG.info("Snapshot location missing for " + snap.getSnapshotId() + ". Skipping deletion from ObjectStorageGateway");
+      LOG.debug("Snapshot location missing for " + snap.getSnapshotId() + ". Skipping deletion from ObjectStorageGateway");
     }
   }
 

--- a/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/async/VolumeCreator.java
+++ b/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/async/VolumeCreator.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2015 Eucalyptus Systems, Inc.
+ * (c) Copyright 2017 Hewlett Packard Enterprise Development Company LP
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -12,11 +12,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
- *
- * Please contact Eucalyptus Systems, Inc., 6755 Hollister Ave., Goleta
- * CA 93117, USA or visit http://www.eucalyptus.com/licenses/ if you need
- * additional information or have any questions.
- *
+ * 
  * This file may incorporate work covered under the following copyright
  * and permission notice:
  *
@@ -126,16 +122,16 @@ public class VolumeCreator implements Runnable {
   @Override
   public void run() {
     boolean success = true;
-    if (snapshotId != null) {
+    if (this.snapshotId != null) {
       try {
-        SnapshotInfo searchFor = new SnapshotInfo(snapshotId);
+        SnapshotInfo searchFor = new SnapshotInfo(this.snapshotId);
         searchFor.setStatus(StorageProperties.Status.available.toString()); // search only for available snapshot in the az
 
         List<SnapshotInfo> foundSnapshotInfos = Transactions.findAll(searchFor);
 
         if (foundSnapshotInfos == null || foundSnapshotInfos.isEmpty()) {
           // SC *may not* have a database record for the snapshot and or the actual snapshot
-          EucaSemaphore semaphore = EucaSemaphoreDirectory.getSolitarySemaphore(snapshotId);
+          EucaSemaphore semaphore = EucaSemaphoreDirectory.getSolitarySemaphore(this.snapshotId);
           try {
             semaphore.acquire(); // Get the semaphore to avoid concurrent access by multiple threads
             foundSnapshotInfos = Transactions.findAll(searchFor); // Check if another thread setup the snapshot
@@ -178,14 +174,14 @@ public class VolumeCreator implements Runnable {
               if (foundSnapshotInfos != null && foundSnapshotInfos.size() > 0) {
                 sourceSnap = foundSnapshotInfos.get(0);
               } else {
-                throw new EucalyptusCloudException("No record of snapshot " + snapshotId + " in any availability zone");
+                throw new EucalyptusCloudException("No record of snapshot " + this.snapshotId + " in any availability zone");
               }
 
               // TODO this might be unnecessary
               // If size was not found in database, bail out. Can't create a snapshot without the size
               if (sourceSnap.getSizeGb() == null || sourceSnap.getSizeGb() <= 0) {
                 throw new EucalyptusCloudException(
-                    "Snapshot size for " + snapshotId + " is unknown. Cannot prep snapshot holder on the storage backend");
+                    "Snapshot size for " + this.snapshotId + " is unknown. Cannot prep snapshot holder on the storage backend");
               }
 
               // Copy base snapshot info to this snapshot
@@ -193,13 +189,13 @@ public class VolumeCreator implements Runnable {
 
               // Check for the snapshot on the storage backend. Clusters/zones/partitions may be connected to the same storage backend in
               // which case snapshot does not have to be downloaded from ObjectStorage.
-              if (!blockManager.getFromBackend(snapshotId, sourceSnap.getSizeGb())) {
+              if (!blockManager.getFromBackend(this.snapshotId, sourceSnap.getSizeGb())) {
                 // Storage backend does not contain snapshot. Download snapshot from OSG
-                LOG.debug(snapshotId + " not found on storage backend. Will attempt to download from objectstorage gateway");
+                LOG.debug(this.snapshotId + " not found on storage backend. Will attempt to download from objectstorage gateway");
 
                 // check whether upload is incremental snapshot
                 if (!Strings.isNullOrEmpty(sourceSnap.getPreviousSnapshotId())) {
-                  LOG.info(snapshotId + " is an incremental snapshot orignating from az " + sourceSnap.getScName());
+                  LOG.info(this.snapshotId + " is an incremental snapshot originating from az " + sourceSnap.getScName());
 
                   // check if backend supports incremental snapshot
                   if (blockManager.supportsIncrementalSnapshots()) {
@@ -222,11 +218,11 @@ public class VolumeCreator implements Runnable {
                     }
                     
                     // Get the snap chain ending with the current snapshot
-                    List<SnapshotInfo> snapChain = blockStorageUtilSvc.getSnapshotChain(prevRestorableSnapsList, snapshotId);
+                    List<SnapshotInfo> snapChain = blockStorageUtilSvc.getSnapshotChain(prevRestorableSnapsList, this.snapshotId);
                     int numDeltas = 0;
                     if (snapChain == null || snapChain.size() == 0) {
                       // This should never happen. The chain should always include at least the current snapshot.
-                      throw new EucalyptusCloudException("Could not find current snapshot " + snapshotId + 
+                      throw new EucalyptusCloudException("Could not find current snapshot " + this.snapshotId + 
                           " in restorable snapshots list");
                     }
                     
@@ -252,7 +248,7 @@ public class VolumeCreator implements Runnable {
                       }
                     }
                     // Cleanup snapshot state and set it up for volume creation
-                    blockManager.completeSnapshotRestorationFromDeltas(snapshotId);
+                    blockManager.completeSnapshotRestorationFromDeltas(this.snapshotId);
                   } else {
                     LOG.warn("Snapshot " + this.snapshotId
                         + " cannot be restored in this availability zone since it does not support incremental snapshots. Failing volume "
@@ -270,7 +266,7 @@ public class VolumeCreator implements Runnable {
 
               } else { // Storage backend contains snapshot
                 // Just create a record of it for this partition in the DB and get going!
-                LOG.debug(snapshotId + " found on storage backend");
+                LOG.debug(this.snapshotId + " found on storage backend");
                 // update the metadata as necessary
                 azSnap.setPreviousSnapshotId(sourceSnap.getPreviousSnapshotId());
                 azSnap.setSnapPointId(sourceSnap.getSnapPointId());
@@ -296,13 +292,13 @@ public class VolumeCreator implements Runnable {
             try {
               semaphore.release();
             } finally {
-              EucaSemaphoreDirectory.removeSemaphore(snapshotId);
+              EucaSemaphoreDirectory.removeSemaphore(this.snapshotId);
             }
           }
 
           // Create the volume from the snapshot, this can happen in parallel.
           if (success) {
-            size = blockManager.createVolume(volumeId, snapshotId, size);
+            this.size = blockManager.createVolume(this.volumeId, this.snapshotId, this.size);
           }
         } else { // SC has a database record for the snapshot
           // Repeated logic, fix it!
@@ -311,51 +307,51 @@ public class VolumeCreator implements Runnable {
             success = false;
             LOG.warn("snapshot " + foundSnapshotInfo.getSnapshotId() + " not available.");
           } else {
-            size = blockManager.createVolume(volumeId, snapshotId, size);
+            this.size = blockManager.createVolume(this.volumeId, this.snapshotId, this.size);
           }
         }
       } catch (Exception ex) {
         success = false;
-        LOG.error("Failed to create volume " + volumeId, ex);
+        LOG.error("Failed to create volume " + this.volumeId, ex);
       }
     } else { // Not a snapshot-based volume create.
       try {
-        if (parentVolumeId != null) {
+        if (this.parentVolumeId != null) {
           // Clone the parent volume.
-          blockManager.cloneVolume(volumeId, parentVolumeId);
+          blockManager.cloneVolume(this.volumeId, this.parentVolumeId);
         } else {
           // Create a regular empty volume
-          blockManager.createVolume(volumeId, size);
+          blockManager.createVolume(this.volumeId, this.size);
         }
       } catch (Exception ex) {
         success = false;
-        LOG.error("Failed to create volume " + volumeId, ex);
+        LOG.error("Failed to create volume " + this.volumeId, ex);
       }
     }
 
     // Update database record for the volume.
-    VolumeInfo volumeInfo = new VolumeInfo(volumeId);
+    VolumeInfo volumeInfo = new VolumeInfo(this.volumeId);
     try (TransactionResource tr = Entities.transactionFor(VolumeInfo.class)) {
       VolumeInfo foundVolumeInfo = Entities.uniqueResult(volumeInfo);
       if (foundVolumeInfo != null) {
         if (success) {
           foundVolumeInfo.setStatus(StorageProperties.Status.available.toString());
-          LOG.debug("Volume " + volumeId + " set to 'available' state");
-          ThruputMetrics.endOperation(snapshotId != null ? MonitoredAction.CREATE_VOLUME_FROM_SNAPSHOT : MonitoredAction.CREATE_VOLUME, volumeId,
+          LOG.debug("Volume " + this.volumeId + " set to 'available' state");
+          ThruputMetrics.endOperation(this.snapshotId != null ? MonitoredAction.CREATE_VOLUME_FROM_SNAPSHOT : MonitoredAction.CREATE_VOLUME, this.volumeId,
               System.currentTimeMillis());
         } else {
           foundVolumeInfo.setStatus(StorageProperties.Status.failed.toString());
-          LOG.debug("Volume " + volumeId + " set to 'failed' state");
+          LOG.debug("Volume " + this.volumeId + " set to 'failed' state");
         }
-        if (snapshotId != null) {
-          foundVolumeInfo.setSize(size);
+        if (this.snapshotId != null) {
+          foundVolumeInfo.setSize(this.size);
         }
       } else {
-        LOG.error("VolumeInfo entity for volume id " + volumeId + " was not found in the database");
+        LOG.error("VolumeInfo entity for volume id " + this.volumeId + " was not found in the database");
       }
       tr.commit();
     } catch (Exception e) {
-      LOG.error("Failed to update VolumeInfo entity for volume id " + volumeId + " in the database", e);
+      LOG.error("Failed to update VolumeInfo entity for volume id " + this.volumeId + " in the database", e);
     }
   }
 

--- a/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/async/VolumeDeleter.java
+++ b/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/async/VolumeDeleter.java
@@ -124,7 +124,7 @@ public class VolumeDeleter extends CheckerTask {
           try (TransactionResource tran = Entities.transactionFor(VolumeInfo.class)) {
             vol = Entities.uniqueResult(vol);
             final String volumeId = vol.getVolumeId();
-            LOG.info("Volume: " + volumeId + " marked for deletion. Checking export status");
+            LOG.debug("Volume: " + volumeId + " marked for deletion. Checking export status");
             if (Iterables.any(vol.getAttachmentTokens(), new Predicate<VolumeToken>() {
               @Override
               public boolean apply(VolumeToken token) {

--- a/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/ceph/CephRbdFormatTwoAdapter.java
+++ b/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/ceph/CephRbdFormatTwoAdapter.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2014 Eucalyptus Systems, Inc.
+ * (c) Copyright 2017 Hewlett Packard Enterprise Development Company LP
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -12,11 +12,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
- *
- * Please contact Eucalyptus Systems, Inc., 6755 Hollister Ave., Goleta
- * CA 93117, USA or visit http://www.eucalyptus.com/licenses/ if you need
- * additional information or have any questions.
- *
+ * 
  * This file may incorporate work covered under the following copyright
  * and permission notice:
  *
@@ -132,7 +128,7 @@ public class CephRbdFormatTwoAdapter implements CephRbdAdapter {
 
   @Override
   public void deleteImage(final String imageName, final String poolName) {
-    LOG.info("Delete ceph-rbd image imageName=" + imageName + ", poolName=" + poolName);
+    LOG.debug("Delete ceph-rbd image imageName=" + imageName + ", poolName=" + poolName);
     executeRbdOpInPool(new Function<CephRbdConnectionManager, String>() {
 
       @Override
@@ -161,7 +157,7 @@ public class CephRbdFormatTwoAdapter implements CephRbdAdapter {
                   LOG.trace("Unprotecting snapshot=" + snap.name + ", image=" + imageName + ", pool=" + arg0.getPool());
                   image.snapUnprotect(snap.name);
                 }
-                LOG.debug("Removing snapshot=" + snap.name + ", image=" + imageName + ", pool=" + arg0.getPool());
+                LOG.info("Removing snapshot=" + snap.name + ", image=" + imageName + ", pool=" + arg0.getPool());
                 image.snapRemove(snap.name);
                 continue;
               }
@@ -173,7 +169,7 @@ public class CephRbdFormatTwoAdapter implements CephRbdAdapter {
           if (canBeDeleted) {
             arg0.getRbd().close(image);
             image = null;
-            LOG.debug("Deleting image=" + imageName + ", pool=" + arg0.getPool());
+            LOG.info("Deleting image=" + imageName + ", pool=" + arg0.getPool());
             arg0.getRbd().remove(imageName);
           } else {
             LOG.debug("Cannot delete image " + imageName + " in pool " + poolName
@@ -202,7 +198,7 @@ public class CephRbdFormatTwoAdapter implements CephRbdAdapter {
 
   @Override
   public void cleanUpImages(final String poolName, final String imagePrefix, final List<String> toBeDeleted) {
-    LOG.info("Cleanup RBD images poolName=" + poolName + ", prefix=" + imagePrefix);
+    LOG.debug("Cleanup RBD images poolName=" + poolName + ", prefix=" + imagePrefix);
     executeRbdOpInPool(new Function<CephRbdConnectionManager, String>() {
 
       @Override
@@ -241,7 +237,7 @@ public class CephRbdFormatTwoAdapter implements CephRbdAdapter {
                         LOG.trace("Unprotecting snapshot=" + snap.name + ", image=" + imageName + ", pool=" + arg0.getPool());
                         image.snapUnprotect(snap.name);
                       }
-                      LOG.debug("Removing snapshot=" + snap.name + ", image=" + imageName + ", pool=" + arg0.getPool());
+                      LOG.info("Removing snapshot=" + snap.name + ", image=" + imageName + ", pool=" + arg0.getPool());
                       image.snapRemove(snap.name);
                       continue;
                     }
@@ -253,7 +249,7 @@ public class CephRbdFormatTwoAdapter implements CephRbdAdapter {
                 if (canBeDeleted) {
                   arg0.getRbd().close(image);
                   image = null;
-                  LOG.debug("Deleting image=" + imageName + ", pool=" + arg0.getPool());
+                  LOG.info("Deleting image=" + imageName + ", pool=" + arg0.getPool());
                   arg0.getRbd().remove(imageName);
                 } else {
                   if (!imageName.startsWith(imagePrefix)) {
@@ -295,7 +291,7 @@ public class CephRbdFormatTwoAdapter implements CephRbdAdapter {
 
   @Override
   public SetMultimap<String, String> cleanUpSnapshots(final String poolName, final SetMultimap<String, String> toBeDeleted) {
-    LOG.info("Cleanup RBD snapshots poolName=" + poolName);
+    LOG.debug("Cleanup RBD snapshots poolName=" + poolName);
     return executeRbdOpInPool(new Function<CephRbdConnectionManager, SetMultimap<String, String>>() {
 
       @Override
@@ -332,7 +328,7 @@ public class CephRbdFormatTwoAdapter implements CephRbdAdapter {
                       LOG.trace("Unprotecting RBD snapshot=" + snapName + ", image=" + imageName + ", pool=" + arg0.getPool());
                       image.snapUnprotect(snapName);
                     }
-                    LOG.debug("Removing RBD snapshot=" + snapName + ", image=" + imageName + ", pool=" + arg0.getPool());
+                    LOG.info("Removing RBD snapshot=" + snapName + ", image=" + imageName + ", pool=" + arg0.getPool());
                     image.snapRemove(snapName);
                   } else {
                     LOG.debug("Cannot delete RBD snapshot=" + snapName + ", image=" + imageName + ", pool=" + poolName
@@ -388,7 +384,7 @@ public class CephRbdFormatTwoAdapter implements CephRbdAdapter {
 
   @Override
   public String getImagePool(final String imageName) {
-    LOG.info("Get ceph-rbd image pool imageName=" + imageName);
+    LOG.debug("Get ceph-rbd image pool imageName=" + imageName);
     return findAndExecuteRbdOp(new Function<CephRbdConnectionManager, String>() {
 
       @Override
@@ -472,7 +468,7 @@ public class CephRbdFormatTwoAdapter implements CephRbdAdapter {
 
   @Override
   public String deleteAllSnapshots(final String imageName, final String poolName, final String snapName) {
-    LOG.info("Delete ceph-rbd snapshots on imageName=" + imageName + ", poolName=" + poolName);
+    LOG.debug("Delete ceph-rbd snapshots on imageName=" + imageName + ", poolName=" + poolName);
     return executeRbdOpInPool(new Function<CephRbdConnectionManager, String>() {
 
       @Override
@@ -491,7 +487,7 @@ public class CephRbdFormatTwoAdapter implements CephRbdAdapter {
                 LOG.trace("Unprotecting snapshot=" + snap.name + ", image=" + imageName + ", pool=" + arg0.getPool());
                 image.snapUnprotect(snap.name);
               }
-              LOG.debug("Removing snapshot=" + snap.name + ", image=" + imageName + ", pool=" + arg0.getPool());
+              LOG.info("Removing snapshot=" + snap.name + ", image=" + imageName + ", pool=" + arg0.getPool());
               image.snapRemove(snap.name);
             }
           }
@@ -540,7 +536,7 @@ public class CephRbdFormatTwoAdapter implements CephRbdAdapter {
   @Override
   public String cloneAndResizeImage(final String parentName, final String snapName, final String cloneName, final Long size,
       final String parentPoolName) {
-    LOG.info("Clone (and resize) ceph-rbd image parentName=" + parentName + ", snapName=" + snapName + ", cloneName=" + cloneName + ", size=" + size
+    LOG.debug("Clone (and resize) ceph-rbd image parentName=" + parentName + ", snapName=" + snapName + ", cloneName=" + cloneName + ", size=" + size
         + ", parentPoolName=" + parentPoolName);
     return executeRbdOpInPool(new Function<CephRbdConnectionManager, String>() {
 
@@ -558,7 +554,7 @@ public class CephRbdFormatTwoAdapter implements CephRbdAdapter {
                 // We only want layering and format 2
                 int features = (1 << 0);
 
-                LOG.debug("Cloning snapshot=" + snapName + ", image=" + parentName + ", pool=" + parentConn.getPool() + " to image=" + cloneName
+                LOG.info("Cloning snapshot=" + snapName + ", image=" + parentName + ", pool=" + parentConn.getPool() + " to image=" + cloneName
                     + ", pool=" + cloneConn.getPool());
                 parentConn.getRbd().clone(parentName, snapName, cloneConn.getIoContext(), cloneName, features, 0);
 
@@ -567,7 +563,7 @@ public class CephRbdFormatTwoAdapter implements CephRbdAdapter {
                   LOG.trace("Opening image=" + cloneName + ", pool=" + cloneConn.getPool() + ", mode=read-write");
                   clone = cloneConn.getRbd().open(cloneName);
 
-                  LOG.debug("Resizing image=" + cloneName + ", pool=" + cloneConn.getPool() + " to " + size + " bytes");
+                  LOG.info("Resizing image=" + cloneName + ", pool=" + cloneConn.getPool() + " to " + size + " bytes");
                   clone.resize(size.longValue());
                 } else {
                   // nothing to do here
@@ -601,7 +597,7 @@ public class CephRbdFormatTwoAdapter implements CephRbdAdapter {
 
   @Override
   public List<String> listPool(final String poolName) {
-    LOG.info("List ceph-rbd pool poolName=" + poolName);
+    LOG.debug("List ceph-rbd pool poolName=" + poolName);
     return executeRbdOpInPool(new Function<CephRbdConnectionManager, List<String>>() {
 
       @Override

--- a/clc/modules/cluster-manager/src/main/java/com/eucalyptus/blockstorage/StorageUtil.java
+++ b/clc/modules/cluster-manager/src/main/java/com/eucalyptus/blockstorage/StorageUtil.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2012 Eucalyptus Systems, Inc.
+ * (c) Copyright 2017 Hewlett Packard Enterprise Development Company LP
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -12,11 +12,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
- *
- * Please contact Eucalyptus Systems, Inc., 6755 Hollister Ave., Goleta
- * CA 93117, USA or visit http://www.eucalyptus.com/licenses/ if you need
- * additional information or have any questions.
- ************************************************************************/
+ *************************************************************************/
 package com.eucalyptus.blockstorage;
 
 import java.util.EnumSet;
@@ -101,8 +97,6 @@ public class StorageUtil {
       mappedState = Optional.of( State.GENERATING );
     } else if ( StorageProperties.Status.pending.toString( ).equals( state ) ) {
       mappedState = Optional.of( State.GENERATING );
-    } else if ( StorageProperties.Status.completed.toString( ).equals( state ) ) {
-      mappedState = Optional.of( State.EXTANT );
     } else if ( StorageProperties.Status.available.toString( ).equals( state ) ) {
       mappedState = Optional.of( State.EXTANT );
     } else if ( StorageProperties.Status.failed.toString( ).equals( state ) ) {


### PR DESCRIPTION
After a snapshot delta is created successfully, wait for its parent (previous)
snapshot to complete (or fail, or timeout) before declaring the delta
available (or failed).
Remove snapshot and volume states that are never set, to avoid confusion
and simplify code.
Use 'this.' notation for clarity to distinguish from same variable names
used as parameters to methods in the same class.
Revise Ceph log levels for certain message to reduce verbosity at INFO level
and right-size important messages.