### PR TITLE
IAM/STS impersonate user administrative utility - EUCA-12370

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -120,6 +120,7 @@ install: build
 	@$(INSTALL) -m 755 clcadmin-assume-system-credentials $(DESTDIR)$(sbindir)/clcadmin-assume-system-credentials
 	@$(INSTALL) -m 755 clcadmin-copy-keys $(DESTDIR)$(sbindir)/clcadmin-copy-keys
 	@$(INSTALL) -m 755 clcadmin-copy-keys $(DESTDIR)$(sbindir)/clusteradmin-copy-keys
+	@$(INSTALL) -m 755 clcadmin-impersonate-user $(DESTDIR)$(sbindir)/clcadmin-impersonate-user
 	@$(INSTALL) -m 755 clcadmin-initialize-cloud $(DESTDIR)$(sbindir)/clcadmin-initialize-cloud
 	@$(INSTALL) -m 755 clusteradmin-register-nodes $(DESTDIR)$(sbindir)/clusteradmin-register-nodes
 	@$(INSTALL) -m 755 clusteradmin-register-nodes $(DESTDIR)$(sbindir)/clusteradmin-deregister-nodes

--- a/tools/clcadmin-impersonate-user
+++ b/tools/clcadmin-impersonate-user
@@ -1,0 +1,148 @@
+#!/usr/bin/python -tt
+#
+# Copyright (c) 2017 Hewlett Packard Enterprise Development LP
+#
+# Redistribution and use of this software in source and binary forms,
+# with or without modification, are permitted provided that the following
+# conditions are met:
+#
+#   Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+#
+#   Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+%(prog)s generates temporary credentials for administrative impersonation
+of accounts (users). Credentials are output in a form suitable for
+running inside an `eval' command.  It must be run by the superuser on an
+active cloud controller.
+"""
+
+from __future__ import unicode_literals
+
+import argparse
+import json
+import logging
+import os
+import pipes
+import subprocess
+import sys
+import urlparse
+
+import boto.sts
+from boto.sts.credentials import Credentials
+from boto.regioninfo import RegionInfo
+
+
+CREDENTIAL_EXE = 'clcadmin-assume-system-credentials'
+REGION_NAME = 'localhost'
+REGION_HOST = '127.0.0.1'
+PORT = 8773
+SERVICE_PATH = '/services/Tokens'
+DURATION_SECS = 900
+
+
+class TokensConnection(boto.sts.STSConnection):
+    def get_impersonation_token(self, account_name, user_name):
+        params = {
+            'AccountAlias': account_name,
+            'UserName': user_name,
+            'DurationSeconds': DURATION_SECS,
+        }
+        if params['UserName'] is None:
+            params['UserName'] = 'admin'
+        return self.get_object('GetImpersonationToken', params,
+                               Credentials, verb='POST')
+
+
+def parse_cli_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '-a', dest='account', required=True,
+        help='the account containing the user (required)')
+    parser.add_argument(
+        '-u', dest='user',
+        help='user to impersonate (optional)')
+    parser.add_argument('-v', dest='verbose', action='count',
+                        help='show more verbose output')
+    return parser.parse_args()
+
+
+def get_creds():
+    proc = subprocess.Popen([CREDENTIAL_EXE], stdout=subprocess.PIPE)
+    for line in proc.stdout:
+        if 'AWS_ACCESS_KEY_ID=' in line:
+            key_id = line.strip().split('=')[1].strip('";')
+        if 'AWS_SECRET_ACCESS_KEY=' in line:
+            secret_key = line.strip().split('=')[1].strip('";')
+    if proc.wait() != 0:
+        raise subprocess.CalledProcessError(proc.returncode, CREDENTIAL_EXE)
+    return key_id, secret_key
+
+
+def print_result(creds):
+    print_var('AWS_ACCESS_KEY_ID', creds.access_key)
+    print_var('AWS_ACCESS_KEY', creds.access_key)
+    print_var('EC2_ACCESS_KEY', creds.access_key)
+    print_var('AWS_SECRET_ACCESS_KEY', creds.secret_key)
+    print_var('AWS_SECRET_KEY', creds.secret_key)
+    print_var('EC2_SECRET_KEY', creds.secret_key)
+    print_var('AWS_SESSION_TOKEN', creds.session_token)
+    print_var('AWS_SECURITY_TOKEN', creds.session_token)
+    print_var('AWS_CREDENTIAL_EXPIRATION', creds.expiration)
+    # Unset other environment to avoid accidental use
+    print_var('AWS_CREDENTIAL_FILE', None)
+    print_var('EC2_USER_ID', None)
+    print
+    print '# These are temporary user credentials'
+    print '#'
+    print '# If you can read this, rerun this program with eval:'
+    print '#     eval `{0}`'.format(
+        ' '.join(pipes.quote(arg) for arg in sys.argv))
+
+
+def print_var(key, val):
+    if val:
+        fmt = '{key}={val}; export {key};'
+    else:
+        fmt = 'unset {key};'
+    print fmt.format(key=key, val=val)
+
+
+def main():
+    args = parse_cli_args()
+    if args.verbose == 1:
+        boto.set_stream_logger('main', logging.INFO)
+    elif args.verbose >= 2:
+        boto.set_stream_logger('main', logging.DEBUG)
+    try:
+        key_id, secret_key = get_creds()
+    except subprocess.CalledProcessError as err:
+        sys.exit('error: obtaining credentials failed ({0})'.format(err))
+    region_info = RegionInfo(name=REGION_NAME, endpoint=REGION_HOST)
+    conn = TokensConnection(aws_access_key_id=key_id,
+                            aws_secret_access_key=secret_key, is_secure=False,
+                            port=PORT, path=SERVICE_PATH, region=region_info)
+    try:
+        imp_creds = conn.get_impersonation_token(args.account, args.user)
+        print_result(imp_creds)
+    except boto.exception.BotoServerError as err:
+        sys.exit('error: {0}'.format(err.message))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This pull request adds a `clcadmin-impersonate-user` command allowing administrators to act as any user via temporary token service credentials.

This relates to the issue:

  https://eucalyptus.atlassian.net/browse/EUCA-12370

Usage:

```
# clcadmin-impersonate-user -h
usage: clcadmin-impersonate-user [-h] -a ACCOUNT [-u USER] [-v]

clcadmin-impersonate-user generates temporary credentials for administrative
impersonation of accounts (users). Credentials are output in a form suitable
for running inside an `eval' command. It must be run by the superuser on an
active cloud controller.

optional arguments:
  -h, --help  show this help message and exit
  -a ACCOUNT  the account containing the user (required)
  -u USER     user to impersonate (optional)
  -v          show more verbose output
```

The command calls `clcadmin-assume-system-credentials` to get administrative credentials and then calls the tokens service to obtain temporary impersonation credentials with a 15 minute duration. The output sets identity and credential environment variables but not endpoints.

Example output:

```
# clcadmin-impersonate-user -a sjones -u sjones
AWS_ACCESS_KEY_ID=AKIAAU2PMSLCBGXU3SMI; export AWS_ACCESS_KEY_ID;
AWS_ACCESS_KEY=AKIAAU2PMSLCBGXU3SMI; export AWS_ACCESS_KEY;
EC2_ACCESS_KEY=AKIAAU2PMSLCBGXU3SMI; export EC2_ACCESS_KEY;
AWS_SECRET_ACCESS_KEY=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; export AWS_SECRET_ACCESS_KEY;
AWS_SECRET_KEY=bsIb9OoyugbZyr7O2W3MfZj6Gj1g3urnnlVyQYRM; export AWS_SECRET_KEY;
EC2_SECRET_KEY=bsIb9OoyugbZyr7O2W3MfZj6Gj1g3urnnlVyQYRM; export EC2_SECRET_KEY;
AWS_SESSION_TOKEN=ZXVjYQAByi9G0Dh516Kn2xMO0ohXh+LB/DsukN0HXk6/HjiDZDYYsbXgWpNHz003cA4Lmy3uSd2p0ooqyiiOHqPGBbborgVz/uTh0b38+ihRUaZHZxsh4FKjTXtvOltkuM8piiXKdv9BefAD0VrI9aK8PIgrmFsXbwEBeCPk2XN9bbsd0RmL5mZOTXnMWmkf/5NkzP7Unwnf9WhJdE0Aon8Swz2msEOJxKMFmI2lo0aKQSsMXrRmuflr3BHW1Y2lHg==; export AWS_SESSION_TOKEN;
AWS_SECURITY_TOKEN=ZXVjYQAByi9G0Dh516Kn2xMO0ohXh+LB/DsukN0HXk6/HjiDZDYYsbXgWpNHz003cA4Lmy3uSd2p0ooqyiiOHqPGBbborgVz/uTh0b38+ihRUaZHZxsh4FKjTXtvOltkuM8piiXKdv9BefAD0VrI9aK8PIgrmFsXbwEBeCPk2XN9bbsd0RmL5mZOTXnMWmkf/5NkzP7Unwnf9WhJdE0Aon8Swz2msEOJxKMFmI2lo0aKQSsMXrRmuflr3BHW1Y2lHg==; export AWS_SECURITY_TOKEN;
AWS_CREDENTIAL_EXPIRATION=2017-02-17T02:02:16.530Z; export AWS_CREDENTIAL_EXPIRATION;
unset AWS_CREDENTIAL_FILE;
unset EC2_USER_ID;

# These are temporary user credentials
#
# If you can read this, rerun this program with eval:
#     eval `/usr/sbin/clcadmin-impersonate-user -a sjones -u sjones`
```

Example use:

```
# 
# eval $(clcadmin-impersonate-user -a sjones -u sjones)
# 
# euare-getcallerid
account = 000469103065
arn = arn:aws:iam::000469103065:user/sjones
key-id = AKIAAPPSNXBO5ZKZSXAM
user-id = AIDAAOTTFWHQR7OHGZ4KG
# 
#
```

The tools/Makefile is update to install the new command.