### PR TITLE
EUCA-13117 snap delete order, and EUCA-13341 snap cleanup for deleted volumes

### DIFF
--- a/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/async/SnapshotDeleter.java
+++ b/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/async/SnapshotDeleter.java
@@ -71,6 +71,7 @@ import org.hibernate.criterion.Restrictions;
 import com.eucalyptus.blockstorage.LogicalStorageManager;
 import com.eucalyptus.blockstorage.S3SnapshotTransfer;
 import com.eucalyptus.blockstorage.entities.SnapshotInfo;
+import com.eucalyptus.blockstorage.entities.SnapshotInfo_;
 import com.eucalyptus.blockstorage.util.StorageProperties;
 import com.eucalyptus.entities.Entities;
 import com.eucalyptus.entities.TransactionResource;
@@ -123,14 +124,15 @@ public class SnapshotDeleter extends CheckerTask {
       try {
         snapshotsToBeDeleted = Transactions.findAll(searchSnap);
       } catch (Exception e) {
-        LOG.error("Failed to lookup snapshots marked for deletion", e);
+        LOG.warn("Failed to lookup snapshots marked for deletion", e);
         return;
       }
       if (snapshotsToBeDeleted != null && !snapshotsToBeDeleted.isEmpty()) {
+        LOG.trace("Deleting snapshots from EBS");
         for (SnapshotInfo snap : snapshotsToBeDeleted) {
           try {
             String snapshotId = snap.getSnapshotId();
-            LOG.debug("Snapshot " + snapshotId + " was marked for deletion from EBS backend. Evaluating prerequistes for cleanup...");
+            LOG.debug("Snapshot " + snapshotId + " was marked for deletion from EBS backend. Evaluating prerequisites for cleanup...");
 
             if (snap.getIsOrigin() != null && snap.getIsOrigin()) { // check if snapshot originates in this az
               // acquire semaphore before deleting to avoid concurrent interaction with delta creation process
@@ -170,16 +172,23 @@ public class SnapshotDeleter extends CheckerTask {
 
   private void deleteFromOSG() {
     try {
-      SnapshotInfo searchSnap = new SnapshotInfo();
-      searchSnap.setStatus(StorageProperties.Status.deletedfromebs.toString());
+      // Get the snapshots that are deleted from EBS but not yet deleted from OSG, 
+      // in reverse time order so we never try to delete a parent before a child
       List<SnapshotInfo> snapshotsToBeDeleted = null;
-      try {
-        snapshotsToBeDeleted = Transactions.findAll(searchSnap);
+      try (TransactionResource tr = Entities.transactionFor(SnapshotInfo.class)) {
+        snapshotsToBeDeleted = Entities.criteriaQuery(
+            Entities.restriction(SnapshotInfo.class)
+            .like(SnapshotInfo_.status, StorageProperties.Status.deletedfromebs.toString()).build())
+            .orderByDesc(SnapshotInfo_.startTime)
+            .list();
+        tr.commit();
       } catch (Exception e) {
-        LOG.warn("Failed to lookup snapshots marked for deletion from OSG", e);
+        LOG.warn("Failed database lookup of snapshots marked for deletion from OSG", e);
         return;
       }
+
       if (snapshotsToBeDeleted != null && !snapshotsToBeDeleted.isEmpty()) {
+        LOG.trace("Deleting snapshots from OSG");
         for (SnapshotInfo snap : snapshotsToBeDeleted) {
           try {
             String snapshotId = snap.getSnapshotId();

--- a/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/ceph/CephRbdAdapter.java
+++ b/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/ceph/CephRbdAdapter.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright 2009-2014 Eucalyptus Systems, Inc.
+ * (c) Copyright 2017 Hewlett Packard Enterprise Development Company LP
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -12,11 +12,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
- *
- * Please contact Eucalyptus Systems, Inc., 6755 Hollister Ave., Goleta
- * CA 93117, USA or visit http://www.eucalyptus.com/licenses/ if you need
- * additional information or have any questions.
- *
+ * 
  * This file may incorporate work covered under the following copyright
  * and permission notice:
  *
@@ -102,17 +98,21 @@ public interface CephRbdAdapter {
    * @param poolName Name of the pool
    * @param imagePrefix Prefix of images that are marked for deletion
    * @param toBeDeleted Set of images that have never been cleaned up
+   * @return Returns a list of RBD snapshot names that were deleted, so their RBD snapshots (not clones) can be removed
+   * from the snapshot-to-be-deleted table. Necessary because the image might be gone by the time cleanUpSnapshots 
+   * runs, and thus it would be unable to delete these snapshots.
    */
-  public void cleanUpImages(String poolName, String imagePrefix, List<String> toBeDeleted);
+  public List<String> cleanUpImages(String poolName, String imagePrefix, List<String> toBeDeleted);
 
   /**
    * Try deleting RBD snapshots and return the ones that cannot deleted since they are busy (parent-child relationship with other images)
    * 
    * @param poolName Name of the pool
+   * @param imagePrefix Prefix of images that are marked for deletion
    * @param toBeDeleted Mapping of image and RBD snapshots to be deleted
    * @return Returns a mapping of RBD image and RBD snapshots that cannot be deleted due to their inheritance
    */
-  public SetMultimap<String, String> cleanUpSnapshots(String poolName, SetMultimap<String, String> toBeDeleted);
+  public SetMultimap<String, String> cleanUpSnapshots(String poolName, String imagePrefix, SetMultimap<String, String> toBeDeleted);
 
   /**
    * Rename RBD image


### PR DESCRIPTION
EUCA-13117: Order the deletion cleanup of snapshot deltas from EBS and OSG
    in reverse date order so parent-child dependencies don't prevent any deltas
    from being cleaned up in one pass.

EUCA-13341: Fix cases where Ceph snapshot cleanup fails on every pass because
    the underlying volume has been deleted. The cleanup now looks for the Ceph
    volume in the deleted prefix list too (where the volume lives while it's
    still needed for snapshots), and when the Ceph volume is truly deleted it
    removes any remaining Ceph snapshots from the to-be-deleted snapshot list.