### PR TITLE
Prevent eucanetd DOS

### DIFF
--- a/net/euca_gni.c
+++ b/net/euca_gni.c
@@ -6298,6 +6298,21 @@ int cmp_gni_secgroup(gni_secgroup *a, gni_secgroup *b, int *ingress_diff, int *e
         } else {
             abmatch = 0;
         }
+        if (a->max_instances == b->max_instances)  {
+            int diffound = 0;
+            for (int i = 0; i < a->max_instances && !diffound; i++) {
+                if (strcmp(a->instances[i]->name, b->instances[i]->name)) {
+                    diffound = 1;
+                }
+            }
+            if (!diffound) {
+                // Who cares
+            } else {
+                abmatch = 0;
+            }
+        } else {
+            abmatch = 0;
+        }
     }
 
     if (abmatch) {

--- a/net/eucanetd_edge.c
+++ b/net/eucanetd_edge.c
@@ -848,6 +848,8 @@ int do_edge_update_sgs(edge_config *edge) {
     snprintf(rule, MAX_RULE_LEN, "-A EUCA_FILTER_FWD -m physdev --physdev-in vn_i+ " 
             "-m set ! --match-set EUCA_NCPRIVATE dst -j ACCEPT");
     ipt_chain_add_rule(edge->config->ipt, "filter", "EUCA_FILTER_FWD", rule);
+
+    vmgwip = hex2dot(edge->config->vmGatewayIP);
     
     // add referenced SG ipsets
     for (i = 0; i < edge->max_ref_sgs; i++) {


### PR DESCRIPTION
The change in:
    https://github.com/eucalyptus/eucalyptus/commit/b56bf5ed1d50b1265efd168d0147569b711b45bc
causes eucanetd to completely fail if you have a SG that trusts another SG with
no instances in it.

Contains my other 2 fixes as prereqs, this fix is just the:

vmgwip = hex2dot(edge->config->vmGatewayIP);

line.