### PR TITLE
EUCA-13433 Bucket Reaper Task improvements (final)

### DIFF
--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/bootstrap/ObjectStorageSchedulerManager.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/bootstrap/ObjectStorageSchedulerManager.java
@@ -105,10 +105,10 @@ public class ObjectStorageSchedulerManager {
   static final String LIFECYCLE_CLEANUP_CLASSNAME = LifecycleReaperJob.class.getName();
   static final String LIFECYCLE_CLEANUP_DEFAULT_SCHEDULE = "0 0 1 * * ?";
   static final String OBJECT_REAPER_CLASSNAME = MainObjectReaperJob.class.getName();
-  static final String OBJECT_REAPER_DEFAULT_SCHEDULE = "interval: 60";
+  static final String OBJECT_REAPER_DEFAULT_SCHEDULE = "interval: 60"; // seconds
   static final String BUCKET_REAPER_CLASSNAME = MainBucketReaperJob.class.getName();
-  static final String BUCKET_REAPER_DEFAULT_SCHEDULE = "interval: 60";
-
+  static final String BUCKET_REAPER_DEFAULT_SCHEDULE = "interval: 1800"; // 30 minutes
+  
   private static Scheduler scheduler = null;
   private static final Lock lock = new ReentrantLock(true);
   private static boolean initted = false;

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/metadata/DbObjectMetadataManagerImpl.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/metadata/DbObjectMetadataManagerImpl.java
@@ -224,6 +224,7 @@ public class DbObjectMetadataManagerImpl implements ObjectMetadataManager {
             obj.setIsLatest(Boolean.FALSE);
             if (latest.getVersionId() != null && ObjectStorageProperties.NULL_VERSION_ID.equals(latest.getVersionId()) && obj.getVersionId() != null
                 && ObjectStorageProperties.NULL_VERSION_ID.equals(obj.getVersionId())) {
+              LOG.trace("Transitioning to deleting");
               transitionObjectToState(obj, ObjectState.deleting);
             }
 
@@ -239,6 +240,7 @@ public class DbObjectMetadataManagerImpl implements ObjectMetadataManager {
     };
 
     try {
+      LOG.trace("Starting cleanup for " + bucket.getBucketName() + "/" + objectKey);
       Entities.asTransaction(repairPredicate).apply(searchExample);
     } catch (final Throwable f) {
       LOG.error("Error in version/null repair", f);


### PR DESCRIPTION
Add tracking numbers of objects and buckets processed.
Lengthen task timeout to 15 minutes every 30 minutes.
Add warning if task times out, identifying last-processed bucket and object.
Do resolveBucketState before cleanObjectHistories.